### PR TITLE
Do not fail on intermediate errors, but fail at the end if there was …

### DIFF
--- a/actions/register.ts
+++ b/actions/register.ts
@@ -4,11 +4,17 @@ import {
   Event,
   TransactionEvent,
   Storage,
+  Log,
 } from "@tenderly/actions";
 import { BytesLike, ethers } from "ethers";
 
-import type { ComposableCoW, IConditionalOrder } from "./types/ComposableCoW";
+import type {
+  ComposableCoW,
+  ComposableCoWInterface,
+  IConditionalOrder,
+} from "./types/ComposableCoW";
 import { ComposableCoW__factory } from "./types/factories/ComposableCoW__factory";
+import { writeRegistry } from "./utils";
 
 /**
  * Listens to these events on the `ComposableCoW` contract:
@@ -19,16 +25,39 @@ import { ComposableCoW__factory } from "./types/factories/ComposableCoW__factory
  */
 export const addContract: ActionFn = async (context: Context, event: Event) => {
   const transactionEvent = event as TransactionEvent;
-  const iface = ComposableCoW__factory.createInterface();
+  const composableCow = ComposableCoW__factory.createInterface();
 
   // Load the registry
   const registry = await Registry.load(context, transactionEvent.network);
 
   // Process the logs
+  let hasErrors = false;
   transactionEvent.logs.forEach((log) => {
+    const { error } = _addContract(log, composableCow, registry);
+    hasErrors ||= error;
+  });
+
+  hasErrors ||= await writeRegistry(registry);
+
+  // Notify error
+  if (hasErrors) {
+    // TODO notify error to slack
+
+    throw Error("Error while processing orders");
+  }
+};
+
+export function _addContract(
+  log: Log,
+  composableCow: ComposableCoWInterface,
+  registry: Registry
+): { error: boolean } {
+  try {
     // Check if the log is a ConditionalOrderCreated event
-    if (log.topics[0] === iface.getEventTopic("ConditionalOrderCreated")) {
-      const [owner, params] = iface.decodeEventLog(
+    if (
+      log.topics[0] === composableCow.getEventTopic("ConditionalOrderCreated")
+    ) {
+      const [owner, params] = composableCow.decodeEventLog(
         "ConditionalOrderCreated",
         log.data,
         log.topics
@@ -36,8 +65,8 @@ export const addContract: ActionFn = async (context: Context, event: Event) => {
 
       // Attempt to add the conditional order to the registry
       add(owner, params, null, log.address, registry);
-    } else if (log.topics[0] == iface.getEventTopic("MerkleRootSet")) {
-      const [owner, root, proof] = iface.decodeEventLog(
+    } else if (log.topics[0] == composableCow.getEventTopic("MerkleRootSet")) {
+      const [owner, root, proof] = composableCow.decodeEventLog(
         "MerkleRootSet",
         log.data,
         log.topics
@@ -73,9 +102,16 @@ export const addContract: ActionFn = async (context: Context, event: Event) => {
         });
       }
     }
-  });
-  await registry.write();
-};
+  } catch (error) {
+    console.error(
+      "[addContract] Error handling ConditionalOrderCreated/MerkleRootSet event",
+      error
+    );
+    return { error: true };
+  }
+
+  return { error: false };
+}
 
 /**
  * Attempt to add an owner's conditional order to the registry

--- a/actions/register.ts
+++ b/actions/register.ts
@@ -37,13 +37,12 @@ export const addContract: ActionFn = async (context: Context, event: Event) => {
     hasErrors ||= error;
   });
 
-  hasErrors ||= await writeRegistry(registry);
-
+  hasErrors ||= !(await writeRegistry(registry));
   // Notify error
   if (hasErrors) {
     // TODO notify error to slack
 
-    throw Error("Error while processing orders");
+    throw Error("Error adding contract for event" + JSON.stringify(event));
   }
 };
 

--- a/actions/utils.ts
+++ b/actions/utils.ts
@@ -3,7 +3,7 @@ import assert = require("assert");
 
 import { ethers } from "ethers";
 import { ConnectionInfo, Logger } from "ethers/lib/utils";
-import { OrderStatus } from "./register";
+import { OrderStatus, Registry } from "./register";
 
 async function getSecret(key: string, context: Context): Promise<string> {
   const value = await context.secrets.get(key);
@@ -69,4 +69,20 @@ export function formatStatus(status: OrderStatus) {
     default:
       return `UNKNOWN (${status})`;
   }
+}
+
+function handlePromiseErrors<T>(
+  errorMessage: string,
+  promise: Promise<T>
+): Promise<boolean> {
+  return promise
+    .then(() => true)
+    .catch((error) => {
+      console.error(errorMessage, error);
+      return false;
+    });
+}
+
+export function writeRegistry(registry: Registry): Promise<boolean> {
+  return handlePromiseErrors("Error writing registry", registry.write());
 }

--- a/actions/utils.ts
+++ b/actions/utils.ts
@@ -71,6 +71,12 @@ export function formatStatus(status: OrderStatus) {
   }
 }
 
+/**
+ * Utility function to handle promise, so they are logged in case of an error. It will return a promise that resolves to true if the promise is successful
+ * @param errorMessage message to log in case of an error (together witht he original error)
+ * @param promise original promise
+ * @returns a promise that returns true if the original promise was successful
+ */
 function handlePromiseErrors<T>(
   errorMessage: string,
   promise: Promise<T>
@@ -79,10 +85,15 @@ function handlePromiseErrors<T>(
     .then(() => true)
     .catch((error) => {
       console.error(errorMessage, error);
-      return false;
+      return true;
     });
 }
 
+/**
+ * Convenient utility to log in case theres an error writing in the registry
+ * @param registry Tenderly registry
+ * @returns a promise that returns true if the registry write was successful
+ */
 export function writeRegistry(registry: Registry): Promise<boolean> {
   return handlePromiseErrors("Error writing registry", registry.write());
 }

--- a/actions/watch.ts
+++ b/actions/watch.ts
@@ -49,13 +49,13 @@ export const checkForSettlement: ActionFn = async (
   });
 
   // Update the registry
-  hasErrors ||= await writeRegistry(registry);
+  hasErrors ||= !(await writeRegistry(registry));
 
   // Notify error
   if (hasErrors) {
     // TODO notify error to slack
 
-    throw Error("Error while processing orders");
+    throw Error("Error while checking the settlements");
   }
 };
 
@@ -164,7 +164,7 @@ export const checkForAndPlaceOrder: ActionFn = async (
   }
 
   // Update the registry
-  hasErrors ||= await writeRegistry(registry);
+  hasErrors ||= await !writeRegistry(registry);
 
   // Notify error
   if (hasErrors) {

--- a/actions/watch.ts
+++ b/actions/watch.ts
@@ -87,8 +87,8 @@ async function _checkForSettlement(
         });
       }
     }
-  } catch (error: any) {
-    console.error("Error checking for settlement", error);
+  } catch (e: any) {
+    console.error("Error checking for settlement" + e?.message, e);
 
     return { error: true };
   }
@@ -109,7 +109,10 @@ async function getTradeableOrderWithSignature(
       conditionalOrder.proof ? conditionalOrder.proof.path : []
     )
     .catch((e) => {
-      console.error('Error during "getTradeableOrderWithSignature" call', e);
+      console.error(
+        'Error during "getTradeableOrderWithSignature" call: ' + e?.message,
+        e
+      );
       throw e;
     });
 }

--- a/actions/watch.ts
+++ b/actions/watch.ts
@@ -137,7 +137,8 @@ export const checkForAndPlaceOrder: ActionFn = async (
     const ordersPendingDelete = [];
     // enumerate all the `ConditionalOrder`s for a given owner
     for (const conditionalOrder of conditionalOrders) {
-      console.log(`Checking params ${conditionalOrder.params}...`);
+      // FIXME: This is a useful log, but it is disabled since Tenderly shows a WARN and start to hide the logs "Logs are too large and have been remove". The effect is, that it hides the posting of the order! (so workaround is to disable)
+      // console.log(`Checking params ${conditionalOrder.params}...`);
       const contract = ComposableCoW__factory.connect(
         conditionalOrder.composableCow,
         chainContext.provider
@@ -301,8 +302,7 @@ async function placeOrder(orderUid: string, order: any, apiUrl: string) {
     };
 
     // if the api_url doesn't contain localhost, post
-    console.log(`[placeOrder] Post order ${orderUid} with params:`, apiUrl);
-    console.log(`[placeOrder] Order:`, postData);
+    console.log(`[placeOrder] Post order ${orderUid}`, postData);
     if (!apiUrl.includes("localhost")) {
       const { status, data } = await axios.post(
         `${apiUrl}/api/v1/orders`,

--- a/actions/watch.ts
+++ b/actions/watch.ts
@@ -137,7 +137,7 @@ export const checkForAndPlaceOrder: ActionFn = async (
     const ordersPendingDelete = [];
     // enumerate all the `ConditionalOrder`s for a given owner
     for (const conditionalOrder of conditionalOrders) {
-      // console.log(`Checking params ${conditionalOrder.params}...`);
+      console.log(`Checking params ${conditionalOrder.params}...`);
       const contract = ComposableCoW__factory.connect(
         conditionalOrder.composableCow,
         chainContext.provider
@@ -301,11 +301,8 @@ async function placeOrder(orderUid: string, order: any, apiUrl: string) {
     };
 
     // if the api_url doesn't contain localhost, post
-    console.log(
-      `[placeOrder] Post order ${orderUid} with params:`,
-      apiUrl,
-      postData
-    );
+    console.log(`[placeOrder] Post order ${orderUid} with params:`, apiUrl);
+    console.log(`[placeOrder] Order:`, postData);
     if (!apiUrl.includes("localhost")) {
       const { status, data } = await axios.post(
         `${apiUrl}/api/v1/orders`,


### PR DESCRIPTION
This PR tries to address some concerns around errors. 

## Hiden errors
Right now, if there's an error processing some logs, or posting the order, Tenderly will still show you that it succeeded.

This is because we catch and handle the errors, so you need to get inside each execution and check the logs in order to see if something is wrong.

## Change applied
This PR will still log every issue, and continue processing until the end, but if there was at least one error, we will throw it at the end of the execution so Tenderly knows that something went badly.

**BEFORE:**
![image](https://github.com/cowprotocol/composable-cow/assets/2352112/b7f41c0f-6cec-46ae-87a3-d6fbf1fd040d)

**AFTER**
<img width="1423" alt="image" src="https://github.com/cowprotocol/composable-cow/assets/2352112/85d1d82e-19a8-48ff-871e-996ffcbacbc3">


This will make it easier to spot the executions that failed


## Not included
Some of these errors could be handled, and shouldn't throw, for example, DuplicatedOrder should be a warning, and not an error (the order is in the system):
<img width="1623" alt="image" src="https://github.com/cowprotocol/composable-cow/assets/2352112/729cabf3-0686-47be-9a1c-19966d88af69">

For now, this PR just want to add more visibility when an error occurs.
