### PR TITLE
Allow to re-process old blocks from local run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ NETWORK=5 # Network to test. 1: Mainnet, 5: Goerli, 100: xDai
 # NODE_USER_100=
 # NODE_PASSWORD_100=
 
-# Optionally, specidy the block number to process locally
+# Optionally, specify the block number to process locally
 #   - useful for debugging or re-apply an old block to make sure the orders are created)
 #   - if not specified, it will run in WATCH mode, subscribing to all new blocks
 #BLOCK_NUMBER=9500767

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,12 @@ NETWORK=5 # Network to test. 1: Mainnet, 5: Goerli, 100: xDai
 # NODE_USER_100=
 # NODE_PASSWORD_100=
 
+# Optionally, specidy the block number to process locally
+#   - useful for debugging or re-apply an old block to make sure the orders are created)
+#   - if not specified, it will run in WATCH mode, subscribing to all new blocks
+#BLOCK_NUMBER=9500767
+BLOCK_NUMBER=
+
 # Slack
 SLACK_WEBHOOK_URL=
 NOTIFICATIONS_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ yarn build:actions
 
 # Run actions locally
 #   - It will start watching and processing new blocks
-#   - As a result, new Composable Cow orders will be discovered and posted to the Orederbook API
+#   - As a result, new Composable Cow orders will be discovered and posted to the OrderBook API
 yarn start:actions
 
 # You can re-process an old block by:

--- a/README.md
+++ b/README.md
@@ -308,7 +308,9 @@ For local integration testing, including the use of [Tenderly Actions](#Tenderly
    SAFE="address here" forge script script/submit_SingleOrder.s.sol:SubmitSingleOrder --rpc-url http://127.0.0.1:8545 --broadcast
    ```
 
-#### Local test for Tenderly Web3 Actions
+#### Run Tenderly Web3 Actions locally
+
+> Useful for debugging locally the actions. Also could be used to create an order for an old block in case there was a failure of WatchTowers indexing it.
 
 Make sure you setup the environment (so you have your own `.env` file).
 
@@ -325,6 +327,13 @@ NODE_PASSWORD_100=optionally-provide-password-if-auth-is-required
 # Build Actions
 yarn build:actions
 
-# Run actions locally, so it starts to checking for new blocks, and executing the actions to create Composable Cow orders)
+# Run actions locally
+#   - It will starts watching and processing new blocks
+#   - As a result, new Composable Cow orders will be discovered and posted to the Orederbook API
+yarn start:actions
+
+# You can re-process an old block by:
+#   - Add an env BLOCK_NUMBER
+#   - Run actions locally
 yarn start:actions
 ```

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ NODE_PASSWORD_100=optionally-provide-password-if-auth-is-required
 yarn build:actions
 
 # Run actions locally
-#   - It will starts watching and processing new blocks
+#   - It will start watching and processing new blocks
 #   - As a result, new Composable Cow orders will be discovered and posted to the Orederbook API
 yarn start:actions
 

--- a/actions/test/run_local.ts
+++ b/actions/test/run_local.ts
@@ -27,7 +27,7 @@ const main = async () => {
     "NOTIFICATIONS_ENABLED",
   ];
   for (const name of envNames) {
-    const envValue = process.env[name]; // || "";
+    const envValue = process.env[name];
     if (envValue) {
       await testRuntime.context.secrets.put(name, envValue);
     }

--- a/actions/test/run_local.ts
+++ b/actions/test/run_local.ts
@@ -37,13 +37,27 @@ const main = async () => {
   const provider = await getProvider(testRuntime.context, network);
   const { chainId } = await provider.getNetwork();
 
-  provider.on("block", async (blockNumber) => {
+  // Provides a way to process an specific block p
+  const blockNumber = process.env.BLOCK_NUMBER;
+
+  const onNewBlock = async (blockNumber: number) => {
     try {
       processBlock(provider, blockNumber, chainId, testRuntime);
     } catch (error) {
       console.error("[run_local] Error in processBlock", error);
     }
-  });
+  };
+
+  if (process.env.BLOCK_NUMBER) {
+    const blockNumber = Number(process.env.BLOCK_NUMBER);
+    console.log(`[run_local] Processing an specicfic block ${blockNumber}...`);
+    await onNewBlock(blockNumber).catch(console.error);
+    console.log(`[run_local] Block ${blockNumber} has been processed.`);
+  } else {
+    // Watch for new blocks
+    console.log(`[run_local] Subscribe to new blocks for network ${network}`);
+    provider.on("block", onNewBlock);
+  }
 };
 
 async function processBlock(
@@ -52,23 +66,7 @@ async function processBlock(
   chainId: number,
   testRuntime: TestRuntime
 ) {
-  // Block watcher for creating new orders
-  const testBlockEvent = new TestBlockEvent();
   const block = await provider.getBlock(blockNumber);
-  testBlockEvent.blockNumber = blockNumber;
-  testBlockEvent.blockDifficulty = block.difficulty.toString();
-  testBlockEvent.blockHash = block.hash;
-  testBlockEvent.network = chainId.toString();
-
-  // run action
-  await testRuntime
-    .execute(checkForAndPlaceOrder, testBlockEvent)
-    .catch((e) => {
-      console.log(
-        "[run_local] Error in checkForAndPlaceOrder processing block",
-        e
-      );
-    });
 
   // Transaction watcher for adding new contracts
   const blockWithTransactions = await provider.getBlockWithTransactions(
@@ -111,6 +109,23 @@ async function processBlock(
         });
     }
   }
+
+  // Block watcher for creating new orders
+  const testBlockEvent = new TestBlockEvent();
+  testBlockEvent.blockNumber = blockNumber;
+  testBlockEvent.blockDifficulty = block.difficulty.toString();
+  testBlockEvent.blockHash = block.hash;
+  testBlockEvent.network = chainId.toString();
+
+  // run action
+  await testRuntime
+    .execute(checkForAndPlaceOrder, testBlockEvent)
+    .catch((e) => {
+      console.log(
+        "[run_local] Error in checkForAndPlaceOrder processing block",
+        e
+      );
+    });
 }
 
 (async () => await main())();

--- a/actions/test/run_local.ts
+++ b/actions/test/run_local.ts
@@ -37,7 +37,7 @@ const main = async () => {
   const provider = await getProvider(testRuntime.context, network);
   const { chainId } = await provider.getNetwork();
 
-  // Provides a way to process an specific block p
+  // Provides a way to process a specific block p
   const blockNumber = process.env.BLOCK_NUMBER;
 
   const onNewBlock = async (blockNumber: number) => {
@@ -50,7 +50,7 @@ const main = async () => {
 
   if (process.env.BLOCK_NUMBER) {
     const blockNumber = Number(process.env.BLOCK_NUMBER);
-    console.log(`[run_local] Processing an specicfic block ${blockNumber}...`);
+    console.log(`[run_local] Processing specific block ${blockNumber}...`);
     await onNewBlock(blockNumber).catch(console.error);
     console.log(`[run_local] Block ${blockNumber} has been processed.`);
   } else {


### PR DESCRIPTION
This PR is to make debugging the WatchTower, and even more importantly, to fix some issues in production that might arise (so we can make ONCALL easier)

## Run actions for a specific block

It makes a small modification in the script that runs locally the actions. Now, it allows you tu run it, instead of in "watch mode" (watching for new blocks), you will be able to run it for a specific block.

## On-call
The idea is, in case during ONCALL someone complaints their smart order is not becoming OPEN when it should, we can:
- Ask the user for a TX, check the block number
- Add that block number in our `.env` file (see this PR changes in the example file)
- Run the actions locally

## How can this be used
This will allow to:
- Create an order in the orderbook but for some reason the WatchTowers failed to create it (i.e. they were temporarily down)
- Debug an issue that prevented the WatchTower to create the order (see image below)


<img width="2040" alt="image" src="https://github.com/cowprotocol/composable-cow/assets/2352112/305802f2-a21a-4784-a9c3-cda707416fa0">


# More context
I added some comments in the code changes