### PR TITLE
Refactor actions and move model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ node_modules/
 /actions/types/
 /cli/artifacts
 /cli/types
+yarn.lock

--- a/actions/addContract.ts
+++ b/actions/addContract.ts
@@ -3,7 +3,6 @@ import {
   Context,
   Event,
   TransactionEvent,
-  Storage,
   Log,
 } from "@tenderly/actions";
 import { BytesLike, ethers } from "ethers";
@@ -14,14 +13,9 @@ import type {
   IConditionalOrder,
 } from "./types/ComposableCoW";
 import { ComposableCoW__factory } from "./types/factories/ComposableCoW__factory";
+
 import { handleExecutionError, init, writeRegistry } from "./utils";
-
-// Standardise the storage key
-const LAST_NOTIFIED_ERROR_STORAGE_KEY = "LAST_NOTIFIED_ERROR";
-
-export const getOrdersStorageKey = (network: string): string => {
-  return `CONDITIONAL_ORDER_REGISTRY_${network}`;
-};
+import { Owner, Proof, Registry } from "./model";
 
 /**
  * Listens to these events on the `ComposableCoW` contract:
@@ -210,150 +204,3 @@ export const flush = async (
     }
   }
 };
-
-// --- Types ---
-
-export enum OrderStatus {
-  SUBMITTED = 1,
-  FILLED = 2,
-}
-
-/**
- * A merkle proof is a set of parameters:
- * - `merkleRoot`: the merkle root of the conditional order
- * - `path`: the path to the order in the merkle tree
- */
-export type Proof = {
-  merkleRoot: BytesLike;
-  path: BytesLike[];
-};
-
-export type OrderUid = BytesLike;
-export type Owner = string;
-
-export type ConditionalOrder = {
-  tx: string; // the transaction hash that created the conditional order (useful for debugging purposes)
-
-  // the parameters of the conditional order
-  params: IConditionalOrder.ConditionalOrderParamsStruct;
-  // the merkle proof if the conditional order is belonging to a merkle root
-  // otherwise, if the conditional order is a single order, this is null
-  proof: Proof | null;
-  // a map of discrete order hashes to their status
-  orders: Map<OrderUid, OrderStatus>;
-  // the address to poll for orders
-  composableCow: string;
-};
-
-/**
- * Models the state beteween executions.
- * Contains a map of owners to conditional orders and the last time we sent an error.
- */
-export class Registry {
-  ownerOrders: Map<Owner, Set<ConditionalOrder>>;
-  storage: Storage;
-  network: string;
-  lastNotifiedError: Date | null;
-
-  /**
-   * Instantiates a registry.
-   * @param ownerOrders What map to populate the registry with
-   * @param storage interface to the Tenderly storage
-   * @param network Which network the registry is for
-   */
-  constructor(
-    ownerOrders: Map<Owner, Set<ConditionalOrder>>,
-    storage: Storage,
-    network: string,
-    lastNotifiedError: Date | null
-  ) {
-    this.ownerOrders = ownerOrders;
-    this.storage = storage;
-    this.network = network;
-    this.lastNotifiedError = lastNotifiedError;
-  }
-
-  /**
-   * Load the registry from storage.
-   * @param context from which to load the registry
-   * @param network that the registry is for
-   * @returns a registry instance
-   */
-  public static async load(
-    context: Context,
-    network: string
-  ): Promise<Registry> {
-    const str = await context.storage.getStr(getOrdersStorageKey(network));
-    const lastNotifiedError = await context.storage
-      .getStr(LAST_NOTIFIED_ERROR_STORAGE_KEY)
-      .then((isoDate) => (isoDate ? new Date(isoDate) : null))
-      .catch(() => null);
-
-    if (str === null || str === undefined || str === "") {
-      return new Registry(
-        new Map<Owner, Set<ConditionalOrder>>(),
-        context.storage,
-        network,
-        lastNotifiedError
-      );
-    }
-
-    const ownerOrders = JSON.parse(str, reviver);
-    return new Registry(
-      ownerOrders,
-      context.storage,
-      network,
-      lastNotifiedError
-    );
-  }
-
-  /**
-   * Write the registry to storage.
-   */
-  public async write(): Promise<void> {
-    const writeOrders = this.storage.putStr(
-      getOrdersStorageKey(this.network),
-      JSON.stringify(this.ownerOrders, replacer)
-    );
-
-    const writeLastNotifiedError =
-      this.lastNotifiedError !== null
-        ? this.storage.putStr(
-            LAST_NOTIFIED_ERROR_STORAGE_KEY,
-            this.lastNotifiedError.toISOString()
-          )
-        : Promise.resolve();
-
-    return Promise.all([writeOrders, writeLastNotifiedError]).then(() => {});
-  }
-}
-
-// --- Helper Functions ---
-
-// Serializing and deserializing Maps and Sets
-export function replacer(_key: any, value: any) {
-  if (value instanceof Map) {
-    return {
-      dataType: "Map",
-      value: Array.from(value.entries()),
-    };
-  } else if (value instanceof Set) {
-    return {
-      dataType: "Set",
-      value: Array.from(value.values()),
-    };
-  } else {
-    return value;
-  }
-}
-
-export function reviver(_key: any, value: any) {
-  if (typeof value === "object" && value !== null) {
-    if (value.dataType === "Map") {
-      return new Map(value.value);
-    } else if (value.dataType === "Set") {
-      return new Set(value.value);
-    }
-  }
-  return value;
-}

--- a/actions/checkForSettlement.ts
+++ b/actions/checkForSettlement.ts
@@ -6,14 +6,6 @@ import {
   Log,
   TransactionEvent,
 } from "@tenderly/actions";
-import {
-  Order,
-  OrderBalance,
-  OrderKind,
-  computeOrderUid,
-} from "@cowprotocol/contracts";
-
-import axios from "axios";
 
 import { BigNumber } from "ethers";
 

--- a/actions/checkForSettlement.ts
+++ b/actions/checkForSettlement.ts
@@ -1,0 +1,115 @@
+import {
+  ActionFn,
+  BlockEvent,
+  Context,
+  Event,
+  Log,
+  TransactionEvent,
+} from "@tenderly/actions";
+import {
+  Order,
+  OrderBalance,
+  OrderKind,
+  computeOrderUid,
+} from "@cowprotocol/contracts";
+
+import axios from "axios";
+
+import { BigNumber } from "ethers";
+
+import { GPv2Settlement__factory } from "./types";
+import { GPv2SettlementInterface } from "./types/GPv2Settlement";
+
+import { handleExecutionError, init, writeRegistry } from "./utils";
+import { OrderStatus, Registry } from "./model";
+
+/**
+ * Watch for settled trades and update the registry
+ * @param context tenderly context
+ * @param event transaction event
+ */
+export const checkForSettlement: ActionFn = async (
+  context: Context,
+  event: Event
+) => {
+  return _checkForSettlement(context, event).catch(handleExecutionError);
+};
+
+/**
+ * Asynchronous version of checkForSettlement. It will process all the settlements, and will throw an error at the end if there was at least one error
+ */
+const _checkForSettlement: ActionFn = async (
+  context: Context,
+  event: Event
+) => {
+  const transactionEvent = event as TransactionEvent;
+  const settlement = GPv2Settlement__factory.createInterface();
+
+  const { registry } = await init(
+    "checkForSettlement",
+    transactionEvent.network,
+    context
+  );
+
+  let hasErrors = false;
+  transactionEvent.logs.forEach(async (log) => {
+    const { error } = await _processSettlement(
+      transactionEvent.hash,
+      log,
+      settlement,
+      registry
+    );
+    hasErrors ||= error;
+  });
+
+  // Update the registry
+  hasErrors ||= !(await writeRegistry());
+
+  // Throw execution error if there was at least one error
+  if (hasErrors) {
+    throw Error(
+      "[checkForSettlement] Error while checking the settlements to mark orders as FILLED"
+    );
+  }
+};
+
+async function _processSettlement(
+  tx: string,
+  log: Log,
+  settlement: GPv2SettlementInterface,
+  registry: Registry
+): Promise<{ error: boolean }> {
+  const { ownerOrders } = registry;
+  try {
+    if (log.topics[0] === settlement.getEventTopic("Trade")) {
+      const [owner, , , , , , orderUid] = settlement.decodeEventLog(
+        "Trade",
+        log.data,
+        log.topics
+      ) as [string, string, string, BigNumber, BigNumber, BigNumber, string];
+
+      // Check if the owner is in the registry
+      if (ownerOrders.has(owner)) {
+        // Get the conditionalOrders for the owner
+        const conditionalOrders = ownerOrders.get(owner);
+        // Iterate over the conditionalOrders and update the status of the orderUid
+        conditionalOrders?.forEach((conditionalOrder) => {
+          // Check if the orderUid is in the conditionalOrder
+          if (conditionalOrder.orders.has(orderUid)) {
+            // Update the status of the orderUid to FILLED
+            console.log(
+              `Update order ${orderUid} to status FILLED. Settlement Tx: ${tx}`
+            );
+            conditionalOrder.orders.set(orderUid, OrderStatus.FILLED);
+          }
+        });
+      }
+    }
+  } catch (e: any) {
+    console.error("Error checking for settlement", e);
+
+    return { error: true };
+  }
+
+  return { error: false };
+}

--- a/actions/model.ts
+++ b/actions/model.ts
@@ -1,0 +1,184 @@
+import Slack = require("node-slack");
+
+import { Context, Storage } from "@tenderly/actions";
+import { Transaction as SentryTransaction } from "@sentry/node";
+import { BytesLike, ethers } from "ethers";
+
+import { apiUrl, getProvider } from "./utils";
+import type { IConditionalOrder } from "./types/ComposableCoW";
+
+// Standardise the storage key
+const LAST_NOTIFIED_ERROR_STORAGE_KEY = "LAST_NOTIFIED_ERROR";
+
+export const getOrdersStorageKey = (network: string): string => {
+  return `CONDITIONAL_ORDER_REGISTRY_${network}`;
+};
+
+export interface ExecutionContext {
+  registry: Registry;
+  notificationsEnabled: boolean;
+  slack?: Slack;
+  sentryTransaction?: SentryTransaction;
+  context: Context;
+}
+
+/**
+ * A merkle proof is a set of parameters:
+ * - `merkleRoot`: the merkle root of the conditional order
+ * - `path`: the path to the order in the merkle tree
+ */
+export type Proof = {
+  merkleRoot: BytesLike;
+  path: BytesLike[];
+};
+
+export type OrderUid = BytesLike;
+export type Owner = string;
+export enum OrderStatus {
+  SUBMITTED = 1,
+  FILLED = 2,
+}
+
+export type ConditionalOrder = {
+  tx: string; // the transaction hash that created the conditional order (useful for debugging purposes)
+
+  // the parameters of the conditional order
+  params: IConditionalOrder.ConditionalOrderParamsStruct;
+  // the merkle proof if the conditional order is belonging to a merkle root
+  // otherwise, if the conditional order is a single order, this is null
+  proof: Proof | null;
+  // a map of discrete order hashes to their status
+  orders: Map<OrderUid, OrderStatus>;
+  // the address to poll for orders
+  composableCow: string;
+};
+
+/**
+ * Models the state beteween executions.
+ * Contains a map of owners to conditional orders and the last time we sent an error.
+ */
+export class Registry {
+  ownerOrders: Map<Owner, Set<ConditionalOrder>>;
+  storage: Storage;
+  network: string;
+  lastNotifiedError: Date | null;
+
+  /**
+   * Instantiates a registry.
+   * @param ownerOrders What map to populate the registry with
+   * @param storage interface to the Tenderly storage
+   * @param network Which network the registry is for
+   */
+  constructor(
+    ownerOrders: Map<Owner, Set<ConditionalOrder>>,
+    storage: Storage,
+    network: string,
+    lastNotifiedError: Date | null
+  ) {
+    this.ownerOrders = ownerOrders;
+    this.storage = storage;
+    this.network = network;
+    this.lastNotifiedError = lastNotifiedError;
+  }
+
+  /**
+   * Load the registry from storage.
+   * @param context from which to load the registry
+   * @param network that the registry is for
+   * @returns a registry instance
+   */
+  public static async load(
+    context: Context,
+    network: string
+  ): Promise<Registry> {
+    const str = await context.storage.getStr(getOrdersStorageKey(network));
+    const lastNotifiedError = await context.storage
+      .getStr(LAST_NOTIFIED_ERROR_STORAGE_KEY)
+      .then((isoDate) => (isoDate ? new Date(isoDate) : null))
+      .catch(() => null);
+
+    if (str === null || str === undefined || str === "") {
+      return new Registry(
+        new Map<Owner, Set<ConditionalOrder>>(),
+        context.storage,
+        network,
+        lastNotifiedError
+      );
+    }
+
+    const ownerOrders = JSON.parse(str, _reviver);
+    return new Registry(
+      ownerOrders,
+      context.storage,
+      network,
+      lastNotifiedError
+    );
+  }
+
+  /**
+   * Write the registry to storage.
+   */
+  public async write(): Promise<void> {
+    const writeOrders = this.storage.putStr(
+      getOrdersStorageKey(this.network),
+      JSON.stringify(this.ownerOrders, replacer)
+    );
+
+    const writeLastNotifiedError =
+      this.lastNotifiedError !== null
+        ? this.storage.putStr(
+            LAST_NOTIFIED_ERROR_STORAGE_KEY,
+            this.lastNotifiedError.toISOString()
+          )
+        : Promise.resolve();
+
+    return Promise.all([writeOrders, writeLastNotifiedError]).then(() => {});
+  }
+}
+
+export class ChainContext {
+  provider: ethers.providers.Provider;
+  api_url: string;
+
+  constructor(provider: ethers.providers.Provider, api_url: string) {
+    this.provider = provider;
+    this.api_url = api_url;
+  }
+
+  public static async create(
+    context: Context,
+    network: string
+  ): Promise<ChainContext> {
+    const provider = await getProvider(context, network);
+
+    const providerNetwork = await provider.getNetwork();
+    return new ChainContext(provider, apiUrl(network));
+  }
+}
+
+export function _reviver(_key: any, value: any) {
+  if (typeof value === "object" && value !== null) {
+    if (value.dataType === "Map") {
+      return new Map(value.value);
+    } else if (value.dataType === "Set") {
+      return new Set(value.value);
+    }
+  }
+  return value;
+}
+
+export function replacer(_key: any, value: any) {
+  if (value instanceof Map) {
+    return {
+      dataType: "Map",
+      value: Array.from(value.entries()),
+    };
+  } else if (value instanceof Set) {
+    return {
+      dataType: "Set",
+      value: Array.from(value.values()),
+    };
+  } else {
+    return value;
+  }
+}

--- a/actions/test/run_local.ts
+++ b/actions/test/run_local.ts
@@ -3,8 +3,8 @@ import {
   TestBlockEvent,
   TestTransactionEvent,
 } from "@tenderly/actions-test";
-import { checkForAndPlaceOrder } from "../watch";
-import { addContract } from "../register";
+import { checkForAndPlaceOrder } from "../checkForAndPlaceOrder";
+import { addContract } from "../addContract";
 import { ethers } from "ethers";
 import assert = require("assert");
 import { getProvider } from "../utils";

--- a/tenderly.yaml
+++ b/tenderly.yaml
@@ -9,7 +9,7 @@ actions:
     specs:
       register_single_order:
         description: Listens to events that index new single conditional orders
-        function: register:addContract
+        function: addContract:addContract
         trigger:
           transaction:
             filters:
@@ -47,7 +47,7 @@ actions:
 
       watch_settlements:
         description: Watch for settled trades and update the state
-        function: watch:checkForSettlement
+        function: checkForSettlement:checkForSettlement
         trigger:
           transaction:
             filters:
@@ -68,7 +68,7 @@ actions:
         description:
           Checks on every block if the registered smart order contract
           wants to trade
-        function: watch:checkForAndPlaceOrder
+        function: checkForAndPlaceOrder:checkForAndPlaceOrder
         trigger:
           block:
             blocks: 5

--- a/tenderly.yaml
+++ b/tenderly.yaml
@@ -28,7 +28,7 @@ actions:
 
       register_merkle_root:
         description: Listens to events that index a merkle root of conditional orders
-        function: register:addContract
+        function: addContract:addContract
         trigger:
           transaction:
             filters:


### PR DESCRIPTION
This PR does a small refacrtor to reduce the complexity of the files. 

The main refactor consist of:
- Each action is in each own file (with the name of the action). So 3 actions, 3 files. Before `watch.rs` had `addContract`, and `checkForAndPlaceOrder`, `checkForSettlement`
- The actions don't have dependencies between them (before there were some models and types defined in the action files). Now action will import some shared utils and models from `utils.ts`  and `model.ts` respectively
- All the type definitions and classes have been moved to `model.ts`


## Additionally
- Cleanup some dead-code pointed out in #43 and addressed in this one
- Fixed an issue writing the registry ([see issue here](https://github.com/cowprotocol/composable-cow/pull/44/files#diff-19bd4b5c3ee627f02c69cc3e706f851803fb2f3a484b50fca1ec03ac788427ebR195)). Now `_handleOrderBookError` is asynchronous. I notice an error happening because we were not waiting for a promise that writes in the registry.

## How to review this PR
Apologies for the number of changes, but its really moving things around only.
The best way to review in my opinion is to checkout the code and check the 3 action files and the model