### PR TITLE
Deploy to dev and prod scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "lint:actions": "eslint && prettier --check ./actions",
     "test:actions": "yarn build:actions && yarn ts-node actions/test/test_register.ts",
     "start:actions": "yarn ts-node actions/test/run_local.ts",
+    "deploy:dev": " tenderly actions deploy --project-config tenderly",
+    "deploy:prod": " tenderly actions deploy --project-config tenderly-prod",
     "fmt:cli": "prettier ./cli -w",
     "lint:cli": "eslint && prettier --check ./cli",
     "build:cli": "cd cli && npm ci && yarn run build",

--- a/tenderly-prod.yaml
+++ b/tenderly-prod.yaml
@@ -1,0 +1,79 @@
+account_id: 9732a0da-5849-4b68-a671-9c4bf1266ca4
+# project_slug: anxolin@gmail.com
+provider: ""
+
+actions:
+  gp-v2/production:
+    runtime: v1
+    sources: actions
+    specs:
+      register_single_order:
+        description: Listens to events that index new single conditional orders
+        function: addContract:addContract
+        trigger:
+          transaction:
+            filters:
+              - logEmitted:
+                  startsWith:
+                    # `ConditionalOrderCreated(address, (address,bytes32,bytes))`
+                    - 0x2cceac5555b0ca45a3744ced542f54b56ad2eb45e521962372eef212a2cbf361
+                network:
+                  - 1
+                  - 5
+                  - 100
+                status: success
+            status:
+              - mined
+          type: transaction
+
+      register_merkle_root:
+        description: Listens to events that index a merkle root of conditional orders
+        function: addContract:addContract
+        trigger:
+          transaction:
+            filters:
+              - logEmitted:
+                  startsWith:
+                    # `MerkleRootSet(address, bytes32, (uint256, bytes))`
+                    - 0x58662f46b4a87d0f96d929b24c37fe25c55d52c0025d0b2bec3936534cc31e57
+                network:
+                  - 1
+                  - 5
+                  - 100
+                status: success
+            status:
+              - mined
+          type: transaction
+
+      watch_settlements:
+        description: Watch for settled trades and update the state
+        function: checkForSettlement:checkForSettlement
+        trigger:
+          transaction:
+            filters:
+              - logEmitted:
+                  startsWith:
+                    # `Trade(address, address, address, uint256, uint256, uint256, bytes)`
+                    - 0xa07a543ab8a018198e99ca0184c93fe9050a79400a0a723441f84de1d972cc17
+                network:
+                  - 1
+                  - 5
+                  - 100
+                status: success
+            status:
+              - mined
+          type: transaction
+
+      watch_orders:
+        description:
+          Checks on every block if the registered smart order contract
+          wants to trade
+        function: checkForAndPlaceOrder:checkForAndPlaceOrder
+        trigger:
+          block:
+            blocks: 5
+            network:
+              - 1
+              - 5
+              - 100
+          type: block


### PR DESCRIPTION
With watch-tower in production, is best to have another environment to run in parallel so we can reiterate on it without fear of breaking production. 

This PR is a WIP, it works but it duplicates the config.

## Test
`yarn deploy:dev` to deploy in dev

`yarn deploy:prod` to deploy in prod

