### PR TITLE
Improve error handling on getTradeableOrderWithSignature CALL simulation

### DIFF
--- a/actions/checkForAndPlaceOrder.ts
+++ b/actions/checkForAndPlaceOrder.ts
@@ -378,7 +378,7 @@ function _handleGetTradableOrderCall(
         };
       case "SingleOrderNotAuthed":
         // If there's no autorization we delete the order
-        // - One reason could be, because the user CACTIONed the order
+        // - One reason could be, because the user CANCELLED the order
         // - for now it doesn't support more advance cases where the order is auth during a pre-interaction
 
         console.info(
@@ -390,7 +390,7 @@ function _handleGetTradableOrderCall(
         };
       case "ProofNotAuthed":
         // If there's no autorization we delete the order
-        // - One reason could be, because the user CACTIONed the order
+        // - One reason could be, because the user CANCELLED the order
         // - for now it doesn't support more advance cases where the order is auth during a pre-interaction
 
         console.info(

--- a/actions/checkForAndPlaceOrder.ts
+++ b/actions/checkForAndPlaceOrder.ts
@@ -378,20 +378,28 @@ function _handleGetTradableOrderCall(
         };
       case "SingleOrderNotAuthed":
         // If there's no autorization we delete the order
-        // for now it doesn't support more advance cases where the order is auth during a pre-interaction
+        // - One reason could be, because the user CACTIONed the order
+        // - for now it doesn't support more advance cases where the order is auth during a pre-interaction
 
-        console.error(
+        console.info(
           `${errorMessagePrefix}: Single order on safe ${owner} not authed. Deleting order...`
         );
-        return { result: CallResult.Failed, deleteConditionalOrder: true };
+        return {
+          result: CallResult.FailedButIsExpected,
+          deleteConditionalOrder: true,
+        };
       case "ProofNotAuthed":
         // If there's no autorization we delete the order
-        // for now it doesn't support more advance cases where the order is auth during a pre-interaction
+        // - One reason could be, because the user CACTIONed the order
+        // - for now it doesn't support more advance cases where the order is auth during a pre-interaction
 
-        console.error(
+        console.info(
           `${errorMessagePrefix}: Proof on safe ${owner} not authed. Deleting order...`
         );
-        return { result: CallResult.Failed, deleteConditionalOrder: true };
+        return {
+          result: CallResult.FailedButIsExpected,
+          deleteConditionalOrder: true,
+        };
     }
 
     console.error(errorMessagePrefix + " for unexpected reasons", error);

--- a/actions/checkForAndPlaceOrder.ts
+++ b/actions/checkForAndPlaceOrder.ts
@@ -116,22 +116,22 @@ async function _processConditionalOrder(
 ): Promise<{ deleteConditionalOrder: boolean; error: boolean }> {
   let error = false;
   try {
-    const tradableOrderResult = await _getTradeableOrderWithSignature(
+    const tradeableOrderResult = await _getTradeableOrderWithSignature(
       owner,
       conditionalOrder,
       contract
     );
 
     // Return early if the simulation fails
-    if (tradableOrderResult.result != CallResult.Success) {
-      const { deleteConditionalOrder, result } = tradableOrderResult;
+    if (tradeableOrderResult.result != CallResult.Success) {
+      const { deleteConditionalOrder, result } = tradeableOrderResult;
       return {
         error: result !== CallResult.FailedButIsExpected, // If we expected the call to fail, then we don't consider it an error
         deleteConditionalOrder,
       };
     }
 
-    const { order, signature } = tradableOrderResult.data;
+    const { order, signature } = tradeableOrderResult.data;
 
     const orderToSubmit: Order = {
       ...order,
@@ -377,9 +377,9 @@ function _handleGetTradableOrderCall(
           deleteConditionalOrder: false,
         };
       case "SingleOrderNotAuthed":
-        // If there's no autorization we delete the order
+        // If there's no authorization we delete the order
         // - One reason could be, because the user CANCELLED the order
-        // - for now it doesn't support more advance cases where the order is auth during a pre-interaction
+        // - for now it doesn't support more advanced cases where the order is auth during a pre-interaction
 
         console.info(
           `${errorMessagePrefix}: Single order on safe ${owner} not authed. Deleting order...`
@@ -389,9 +389,9 @@ function _handleGetTradableOrderCall(
           deleteConditionalOrder: true,
         };
       case "ProofNotAuthed":
-        // If there's no autorization we delete the order
+        // If there's no authorization we delete the order
         // - One reason could be, because the user CANCELLED the order
-        // - for now it doesn't support more advance cases where the order is auth during a pre-interaction
+        // - for now it doesn't support more advanced cases where the order is auth during a pre-interaction
 
         console.info(
           `${errorMessagePrefix}: Proof on safe ${owner} not authed. Deleting order...`


### PR DESCRIPTION
Most of the erros happen during `getTradeableOrderWithSignature` `CALL` simulation.

There's many things that can go wrong here.

This error tries to make it more explicit the error handling, so it signals igiven the error, we should re-attempt later. Also, if this is expected or just an un-expeted errors. 


Expected errors won't lead to the TENDERLY action to fail. 
Un-expected will.

If the error handler decides that we shouldn't re-attempt later (its a final error), then it will signal that the order should be deleted. 


## Special mention
I changed slightly the implementation, @mfw78 pls double check if it makes sense now. 

Before, we were deleting the order in case of unforeseen or un-recognised errors. This could be for example because of a temporal network failure or rate limiting or sth, so we should definitely re-attempt later.


see https://github.com/cowprotocol/composable-cow/pull/46/files#diff-8e2dc90f4a6ebdf01f8603707f37f7794972fdf1827102bfce89497804f72837R398

## Edit 
Analysing [this case](https://cowprotocol.sentry.io/issues/4404087467/?project=4505714328928256&query=is%3Aunresolved+level%3Aerror&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=0 ), i changed this PR to make less noise when 

This order was created, and there was an AUTH, but it was revoked after doing a cancelation.

Its fine to delete the order, and I don't think we should make so much noise in these cases: 33e80fa3e71d4f7e5b5326e3dcccfb4c1e75b1ff

