### PR TITLE
feature: Handle cancellations: Reduce errors and logs

### DIFF
--- a/actions/utils.ts
+++ b/actions/utils.ts
@@ -287,7 +287,7 @@ var consoleOriginal = {
 
 // Override the log function since some internal libraries might print something and breaks Tenderly
 
-// console.warn = logWithLimit["warn"];
+// console.warn = logWithLimit("warn");
 // console.error = logWithLimit("error");
 // console.debug = logWithLimit("debug");
 // console.log = logWithLimit("log");

--- a/actions/utils.ts
+++ b/actions/utils.ts
@@ -14,7 +14,7 @@ import { CaptureConsole as CaptureConsoleIntegration } from "@sentry/integration
 
 import { ExecutionContext, OrderStatus, Registry } from "./model";
 
-const TENDERLY_LOG_LIMIT = 3800; // 4000 is the limit, we just leave some margin for printing the chunk index
+// const TENDERLY_LOG_LIMIT = 3800; // 4000 is the limit, we just leave some margin for printing the chunk index
 const NOTIFICATION_WAIT_PERIOD = 1000 * 60 * 60 * 2; // 2h - Don't send more than one notification every 2h
 
 let executionContext: ExecutionContext | undefined;
@@ -244,52 +244,53 @@ var consoleOriginal = {
   debug: console.debug,
 };
 
-/**
- * Tenderly has a limit of 4Kb per log message. When you surpass this limit, the log is not printed any more making it super hard to debug anything
- *
- * This tool will print
- *
- * @param data T
- */
-const logWithLimit =
-  (level: "log" | "warn" | "error" | "debug") =>
-  (...data: any[]) => {
-    const bigLogText = data
-      .map((item) => {
-        if (typeof item === "string") {
-          return item;
-        }
-        return JSON.stringify(item, null, 2);
-      })
-      .join(" ");
+// TODO: Delete this code after we sort out the Tenderly log limit issue
+// /**
+//  * Tenderly has a limit of 4Kb per log message. When you surpass this limit, the log is not printed any more making it super hard to debug anything
+//  *
+//  * This tool will print
+//  *
+//  * @param data T
+//  */
+// const logWithLimit =
+//   (level: "log" | "warn" | "error" | "debug") =>
+//   (...data: any[]) => {
+//     const bigLogText = data
+//       .map((item) => {
+//         if (typeof item === "string") {
+//           return item;
+//         }
+//         return JSON.stringify(item, null, 2);
+//       })
+//       .join(" ");
 
-    const numChunks = Math.ceil(bigLogText.length / TENDERLY_LOG_LIMIT);
+//     const numChunks = Math.ceil(bigLogText.length / TENDERLY_LOG_LIMIT);
 
-    for (let i = 0; i < numChunks; i += 1) {
-      const chartStart = i * TENDERLY_LOG_LIMIT;
-      const prefix = numChunks > 1 ? `[${i + 1}/${numChunks}] ` : "";
-      const message =
-        prefix +
-        bigLogText.substring(chartStart, chartStart + TENDERLY_LOG_LIMIT);
-      consoleOriginal[level](message);
+//     for (let i = 0; i < numChunks; i += 1) {
+//       const chartStart = i * TENDERLY_LOG_LIMIT;
+//       const prefix = numChunks > 1 ? `[${i + 1}/${numChunks}] ` : "";
+//       const message =
+//         prefix +
+//         bigLogText.substring(chartStart, chartStart + TENDERLY_LOG_LIMIT);
+//       consoleOriginal[level](message);
 
-      // if (level === "error") {
-      //   sendSlack(message);
-      // }
+//       // if (level === "error") {
+//       //   sendSlack(message);
+//       // }
 
-      // // Used to debug the Tenderly log Limit issues
-      // consoleOriginal[level](
-      //   prefix + "TEST for bigLogText of " + bigLogText.length + " bytes"
-      // );
-    }
-  };
+//       // // Used to debug the Tenderly log Limit issues
+//       // consoleOriginal[level](
+//       //   prefix + "TEST for bigLogText of " + bigLogText.length + " bytes"
+//       // );
+//     }
+//   };
 
 // Override the log function since some internal libraries might print something and breaks Tenderly
 
-console.warn = logWithLimit("warn");
-console.error = logWithLimit("error");
-console.debug = logWithLimit("debug");
-console.log = logWithLimit("log");
+// console.warn = logWithLimit["warn"];
+// console.error = logWithLimit("error");
+// console.debug = logWithLimit("debug");
+// console.log = logWithLimit("log");
 
 export function sendSlack(message: string): boolean {
   if (!executionContext) {


### PR DESCRIPTION
This PR aims to handle cancelations of smart orders better.

## Why
Currently, a big a mount of the errors in the logs comes from Smart Order cancelations

The error handling  of `getTradeableOrderWithSignature` will try to guess if the issue with the CALL was because of the auth:
https://github.com/cowprotocol/composable-cow/blob/81fc6615b37f2482b45586ed6237f94a37833238/actions/checkForAndPlaceOrder.ts#L420

The problem is that sometimes (at least in Gnosis Chain), the EVM error will not give you this nice debug info, so basically you don't know why it failed. 

## The Problem
If we are not sure about the problem, we can't remove the order from the pending orders, so we will keep getting this error over and over for every block.

## Additional problem
Debugging Smart Orders take a lot of time, and there are too many things that can be wrong. If we need to debug these situations manually, it will be very time consuming

## This PR proposal
Before doing the `getTradeableOrderWithSignature` CALL, we check for `singleOrders` flow if the order is authorised or not. 

If its not authorised, we remove the order from the pending orders, and continue (we don't consider this an error, this is part of the normal flow on cancelations)

## Example 
This Order was failing over and over:

* Network: 100
* Tenderly Simulation: https://dashboard.tenderly.co/gp-v2/watch-tower-prod/simulator/01a611cc-2eaa-4c4a-b97b-48272c38596f/debugger?trace=0 
* Tx: 0xcf62a4ff38ae24015269c41dbf3b9f70e3b4ac711d7a08c4b001f412f48e3ba5
* Owner: 0xe60d513f367326c70f447875984940ccf9348b3c
    * Safe History: https://app.safe.global/transactions/history?safe=gno:0xe60d513f367326c70f447875984940ccf9348b3c 
* CTX: 0x7071fe884758b2091859f5292d5ff204b21a38549c26af366dfb2f3325de0364


As you can see in the history:
https://app.safe.global/transactions/history?safe=gno:0xe60d513f367326c70f447875984940ccf9348b3c

This order was created in NONCE 0 (https://gnosisscan.io/tx/0xcf62a4ff38ae24015269c41dbf3b9f70e3b4ac711d7a08c4b001f412f48e3ba5/), and canceled in NONCE 1 (https://gnosisscan.io/tx/0xf494ac79b5f7cb4fce8e6298f6ac6c6c73295ffb90e105914a6402934812dff0/)