### PR TITLE
Validate orders using custom handlers

### DIFF
--- a/actions/handlers/index.ts
+++ b/actions/handlers/index.ts
@@ -1,0 +1,27 @@
+import {
+  SmartOrderValidationResult,
+  SmartOrderValidator,
+  ValidateOrderParams,
+} from "../model";
+
+import {
+  handlerAddress as handlerTwap,
+  validateOrder as validateOrderTwap,
+} from "./twap";
+
+const validatorsForHandler: Record<string, SmartOrderValidator> = {
+  [handlerTwap.toLowerCase()]: validateOrderTwap,
+};
+
+/**
+ * Validate a smart order using the custom handler logic (if known)
+ *
+ * @returns The result of the validation if the handler is known, undefined otherwise
+ */
+export async function validateOrder(
+  params: ValidateOrderParams
+): Promise<SmartOrderValidationResult<void> | undefined> {
+  const { handler } = params;
+  const validateFn = validatorsForHandler[handler.toLowerCase()];
+  return validateFn ? validateFn(params) : undefined;
+}

--- a/actions/handlers/twap.ts
+++ b/actions/handlers/twap.ts
@@ -1,0 +1,14 @@
+import { TWAP_ADDRESS } from "@cowprotocol/cow-sdk";
+
+import { SmartOrderValidator, ValidationResult } from "../model";
+
+export const handlerAddress = TWAP_ADDRESS;
+
+export const validateOrder: SmartOrderValidator = async (_params) => {
+  // TODO: Implement validation logic, ideally delegate to the SDK
+
+  return {
+    result: ValidationResult.Success,
+    data: undefined,
+  };
+};

--- a/actions/model.ts
+++ b/actions/model.ts
@@ -182,3 +182,32 @@ export function replacer(_key: any, value: any) {
     return value;
   }
 }
+
+export type SmartOrderValidationResult<T> =
+  | SmartOrderValidationSuccess<T>
+  | SmartOrderValidationError;
+
+export enum ValidationResult {
+  Success,
+  Failed,
+  FailedButIsExpected,
+}
+
+export type SmartOrderValidationSuccess<T> = {
+  result: ValidationResult.Success;
+  data: T;
+};
+export type SmartOrderValidationError = {
+  result: ValidationResult.Failed | ValidationResult.FailedButIsExpected;
+  deleteConditionalOrder: boolean;
+  errorObj: any;
+};
+
+export type SmartOrderValidator = (
+  params: ValidateOrderParams
+) => Promise<SmartOrderValidationResult<void>>;
+export interface ValidateOrderParams {
+  handler: string;
+  salt: BytesLike;
+  staticInput: BytesLike;
+}

--- a/actions/package.json
+++ b/actions/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@cowprotocol/contracts": "^1.4.0",
+    "@cowprotocol/cow-sdk": "^2.4.0-rc.0",
     "@sentry/integrations": "^7.64.0",
     "@sentry/node": "^7.64.0",
     "@tenderly/actions": "^0.0.13",


### PR DESCRIPTION
This PR adds some basic mechanisms to introduce custom validations for specific handlers

The idea is to be able to verify things like: "TWAP order is already expired' which will allow us to not check for this order again 

This PR just adds the placeholder to introduce the logic, and defines the interfaces of the validation.

I will leave some comments in the code to explain this PR. 

## checkForAndPlaceOrders
Now this action will use a new method called `validateOrder`.

It will allows this action to perform some specific smart order validations without introducing specific logic in the main actions logic. 

All this algorithm will care is about the result of the validation. The specific implementation will signal if the order should be deleted (so its not checked again), and if there was an error doing the validation, and if this error was expected or unexpected.

Expected errors are for example: is not yet time to place an order

Unexpected errors are for example: Error querying the node

Expected errors will not result in Tenderly to fail. It will still show success. Also we won't try to do the CALL to `getTradeableOrderWithSignature` so this will reduce a lot the lofa

## cow-SDK
This PR adds a dependency with the SDK, so it can make use of its logic. 

Ideally, the validation logic should live there. Also, future PRs should consider using the OrderBook API through the SDK and not though an ad-hoc axios request.

## For more details
Check the code, i will add some comments there