### PR TITLE
fix: flaky test

### DIFF
--- a/test/ComposableCoW.twap.t.sol
+++ b/test/ComposableCoW.twap.t.sol
@@ -184,7 +184,8 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
      */
     function test_getTradeableOrder_FuzzRevertIfExpired(uint256 startTime, uint256 currentTime) public {
         // guard against overflows
-        vm.assume(startTime < type(uint32).max);
+        vm.assume(startTime <= type(uint32).max);
+        vm.assume(currentTime <= type(uint32).max);
         // force revert after expiry
         vm.assume(currentTime >= startTime + (FREQUENCY * NUM_PARTS));
 


### PR DESCRIPTION
This PR:

1. Applies a small fix to enforce `SafeCast` conditions on the fuzz test's parameters.