### PR TITLE
cicd: add issues to project

### DIFF
--- a/.github/workflows/add-action-project.yml
+++ b/.github/workflows/add-action-project.yml
@@ -1,0 +1,16 @@
+name: Add new issues to project board
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    if: github.repository_owner == 'cowprotocol'
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/cowprotocol/projects/8
+          github-token: ${{ secrets.ORG_TOKEN }}


### PR DESCRIPTION
This PR:

1. Adds CI/CD workflows to automatically add issues / PRs to project management.