### PR TITLE
fix: actually do the template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,8 +26,8 @@ A clear and concise description of what you expected to happen.
 ### Screenshots/logs
 If applicable, add screenshots or logs to help explain your problem.
 
-### <!-- repo / package --> version/commit hash
-State the version of <!-- insert package --> where you've encountered the bug or, if built off a specific commit, the relevant commit hash. <!-- If applicable, provide hints as to how to retrieve the commit hash -->.
+### ComposableCoW version/commit hash
+State the version of ComposableCoW where you've encountered the bug or, if built off a specific commit, the relevant commit hash.
 - e.g. `v0.9` or `ed53bcd`
 
 ### Additional context

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for the <!-- project --> implementation
+about: Suggest an idea for ComposableCoW
 title: 'feat: '
 labels: track:production
 assignees: ''


### PR DESCRIPTION
# Description

Aspects of the templates for issues were not properly set when merged previously, necessitating this fix PR.

# Changes

- [x] Feature request updated
- [x] Bug report updated

## How to test

View the pretty new templates in the GitHub issues by attempting to create a new issue.