### PR TITLE
cicd: cla workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,23 @@
+name: "cla"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: ((github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target') && github.repository_owner == 'cowprotocol' && github.repository != 'cowprotocol/cla'
+        uses: contributor-assistant/github-action@v2.2.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.ORG_TOKEN }}
+        with:
+          branch: 'cla-signatures'
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/cowprotocol/cla/blob/main/CLA.md'
+          allowlist: '*[bot]'


### PR DESCRIPTION
# Description
As part of the External Contributor Friendly epic, external contributors will need to sign the CLA per current procedures. This PR addresses precisely this to enable CLA signing.

# Changes

- [x] Enables the CLA signatures workflow.

## How to test
On your next PR, sign the CLA :pen: 