### PR TITLE
feat: watch tower / sdk friendly expanded interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,23 +76,15 @@ For a detailed explanation of the respective order types, please see their respe
 
 ### Deployed Contracts
 
-| Contract Name                  | Ethereum Mainnet                                                                                                      | Goerli                                                                                                                       | Gnosis Chain                                                                                                           |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `ExtensibleFallbackHandler`    | [0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5](https://etherscan.io/address/0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5) | [0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5](https://goerli.etherscan.io/address/0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5) | [0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5](https://gnosisscan.io/address/0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5) |
-| `ComposableCoW`                | [0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74](https://etherscan.io/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74) | [0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74](https://goerli.etherscan.io/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74) | [0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74](https://gnosisscan.io/address/0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74) |
-| `TWAP`                         | [0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5](https://etherscan.io/address/0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5) | [0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5](https://goerli.etherscan.io/address/0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5) | [0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5](https://gnosisscan.io/address/0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5) |
-| `GoodAfterTime`                | [0xd3338f21c89745e46af56aeaf553cf96ba9bc66f](https://etherscan.io/address/0xd3338f21c89745e46af56aeaf553cf96ba9bc66f) | [0xd3338f21c89745e46af56aeaf553cf96ba9bc66f](https://goerli.etherscan.io/address/0xd3338f21c89745e46af56aeaf553cf96ba9bc66f) | [0xd3338f21c89745e46af56aeaf553cf96ba9bc66f](https://gnosisscan.io/address/0xd3338f21c89745e46af56aeaf553cf96ba9bc66f) |
-| `PerpetualStableSwap`          | [0x519BA24e959E33b3B6220CA98bd353d8c2D89920](https://etherscan.io/address/0x519BA24e959E33b3B6220CA98bd353d8c2D89920) | [0x519BA24e959E33b3B6220CA98bd353d8c2D89920](https://goerli.etherscan.io/address/0x519BA24e959E33b3B6220CA98bd353d8c2D89920) | [0x519BA24e959E33b3B6220CA98bd353d8c2D89920](https://gnosisscan.io/address/0x519BA24e959E33b3B6220CA98bd353d8c2D89920) |
-| `TradeAboveThreshold`          | [0x44569Cbd4E10dd5e97293337964Eff32d58ed352](https://etherscan.io/address/0x44569Cbd4E10dd5e97293337964Eff32d58ed352) | [0x44569Cbd4E10dd5e97293337964Eff32d58ed352](https://goerli.etherscan.io/address/0x44569Cbd4E10dd5e97293337964Eff32d58ed352) | [0x44569Cbd4E10dd5e97293337964Eff32d58ed352](https://gnosisscan.io/address/0x44569Cbd4E10dd5e97293337964Eff32d58ed352) |
-| `StopLoss`                     | [0xE8212F30C28B4AAB467DF3725C14d6e89C2eB967](https://etherscan.io/address/0xE8212F30C28B4AAB467DF3725C14d6e89C2eB967) | [0xE8212F30C28B4AAB467DF3725C14d6e89C2eB967](https://goerli.etherscan.io/address/0xE8212F30C28B4AAB467DF3725C14d6e89C2eB967) | [0xE8212F30C28B4AAB467DF3725C14d6e89C2eB967](https://gnosisscan.io/address/0xE8212F30C28B4AAB467DF3725C14d6e89C2eB967) |
-| `CurrentBlockTimestampFactory` | [0x52eD56Da04309Aca4c3FECC595298d80C2f16BAc](https://etherscan.io/address/0x52eD56Da04309Aca4c3FECC595298d80C2f16BAc) | [0x52eD56Da04309Aca4c3FECC595298d80C2f16BAc](https://goerli.etherscan.io/address/0x52eD56Da04309Aca4c3FECC595298d80C2f16BAc) | [0x52eD56Da04309Aca4c3FECC595298d80C2f16BAc](https://gnosisscan.io/address/0x52eD56Da04309Aca4c3FECC595298d80C2f16BAc) |
+**WARNING**: No contracts from this branch have been deployed to production (mainnet / Gnosis Chain) and should not be used in production.
+
+| Contract Name                  | Goerli                                                                                                      |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+|  |  |
 
 #### Audits
 
-The above deployed contracts have been audited by:
-
-- Ackee Blockchain: [CoW Protocol - `ComposableCoW` and `ExtensibleFallbackHandler`](./audits/ackee-blockchain-cow-protocol-composablecow-extensiblefallbackhandler-report-1.2.pdf)
-- Gnosis internal audit: [ComposableCoW - May/July 2023](./audits/gnosis-ComposableCoWMayJul2023.pdf)
+**WARNING**: This is branch contains changes that have not been audited. Please use the `main` branch for the latest audited version.
 
 ### Environment setup
 

--- a/src/BaseConditionalOrder.sol
+++ b/src/BaseConditionalOrder.sol
@@ -57,4 +57,8 @@ abstract contract BaseConditionalOrder is IConditionalOrderGenerator {
     function supportsInterface(bytes4 interfaceId) external view virtual override returns (bool) {
         return interfaceId == type(IConditionalOrderGenerator).interfaceId || interfaceId == type(IERC165).interfaceId;
     }
+
+    function validateData(bytes memory data) external view virtual override {
+        // --- no-op
+    }
 }

--- a/src/interfaces/IConditionalOrder.sol
+++ b/src/interfaces/IConditionalOrder.sol
@@ -14,6 +14,16 @@ interface IConditionalOrder {
     ///      A parameter of `string` type is included to allow the caller to specify the reason for the failure.
     error OrderNotValid(string);
 
+    // --- errors specific for polling
+    // Signal to a watch tower that polling should be attempted again.
+    error PollTryNextBlock(string reason);
+    // Signal to a watch tower that polling should be attempted again at a specific block number.
+    error PollTryAtBlock(uint256 blockNumber, string reason);
+    // Signal to a watch tower that polling should be attempted again at a specific epoch (unix timestamp).
+    error PollTryAtEpoch(uint256 timestamp, string reason);
+    // Signal to a watch tower that the conditional order should not be polled again (delete).
+    error PollNever(string reason);
+
     /**
      * @dev This struct is used to uniquely identify a conditional order for an owner.
      *      H(handler || salt || staticInput) **MUST** be unique for an owner.
@@ -50,6 +60,13 @@ interface IConditionalOrder {
         bytes calldata offchainInput,
         GPv2Order.Data calldata order
     ) external view;
+
+    /**
+     * A helper function for SDK users to verify if a given conditional order's data is valid.
+     * @param data The ABI-encoded concrete order type's `Data` struct to be validated.
+     * @dev Throws if the data is invalid.
+     */
+    function validateData(bytes memory data) external view;
 }
 
 /**

--- a/src/types/twap/TWAP.sol
+++ b/src/types/twap/TWAP.sol
@@ -59,4 +59,12 @@ contract TWAP is BaseConditionalOrder {
             revert IConditionalOrder.OrderNotValid(NOT_WITHIN_SPAN);
         }
     }
+
+    /**
+     * @inheritdoc IConditionalOrder
+     */
+    function validateData(bytes memory data) external override pure {
+        TWAPOrder.validate(abi.decode(data, (TWAPOrder.Data)));
+    }
+
 }

--- a/src/types/twap/libraries/TWAPOrderMathLib.sol
+++ b/src/types/twap/libraries/TWAPOrderMathLib.sol
@@ -39,7 +39,7 @@ library TWAPOrderMathLib {
 
         unchecked {
             /// @dev Order is not valid before the start (order commences at `t0`).
-            if (!(startTime <= block.timestamp)) revert IConditionalOrder.OrderNotValid(BEFORE_TWAP_START);
+            if (!(startTime <= block.timestamp)) revert IConditionalOrder.PollTryAtEpoch(startTime, BEFORE_TWAP_START);
 
             /**
              *  @dev Order is expired after the last part (`n` parts, running at `t` time length).
@@ -51,7 +51,7 @@ library TWAPOrderMathLib {
              * `type(uint32).max` so the sum of `startTime + (numParts * frequency)` is ≈ 2⁵⁵.
              */
             if (!(block.timestamp < startTime + (numParts * frequency))) {
-                revert IConditionalOrder.OrderNotValid(AFTER_TWAP_FINISH);
+                revert IConditionalOrder.PollNever(AFTER_TWAP_FINISH);
             }
 
             /**

--- a/test/ComposableCoW.base.t.sol
+++ b/test/ComposableCoW.base.t.sol
@@ -296,4 +296,8 @@ contract MirrorConditionalOrder is IConditionalOrder {
             revert(0, calldatasize())
         }
     }
+
+    function validateData(bytes calldata) external pure override {
+        // --- no-op
+    }
 }


### PR DESCRIPTION
# Description

Provides expanded `IConditionalOrder` interfaces with parameterized errors as these are required to standardise such that the conditional order is able to communicate it's indexing intent to a watch tower.

**NOTE**: Replaces #73 that was closed in error.

# Changes

- [x] Add custom parameterized errors for watch tower indexing.
- [x] `validateData` external function for verifying a conditional order's data struct if granular verification has been implemented (recommended for order type developers).

## How to test
The TWAP contract has been updated to implement the expanded interface. To test:

```bash
forge test
```

## Related Issues

Closes #72 