### PR TITLE
tests: revert with more than 4bytes

### DIFF
--- a/src/types/twap/TWAP.sol
+++ b/src/types/twap/TWAP.sol
@@ -76,8 +76,7 @@ contract TWAP is BaseConditionalOrder {
     /**
      * @inheritdoc IConditionalOrder
      */
-    function validateData(bytes memory data) external override pure {
+    function validateData(bytes memory data) external pure override {
         TWAPOrder.validate(abi.decode(data, (TWAPOrder.Data)));
     }
-
 }

--- a/test/ComposableCoW.base.t.sol
+++ b/test/ComposableCoW.base.t.sol
@@ -195,7 +195,7 @@ contract BaseComposableCoWTest is Base, Merkle {
     }
 
     function getPassthroughOrder() internal view returns (IConditionalOrder.ConditionalOrderParams memory) {
-        return createOrder(passThrough, keccak256("pass through order"), bytes(""));
+        return createOrder(passThrough, keccak256("pass through order"), hex"");
     }
 
     function getBundle(Safe safe, uint256 n)
@@ -233,6 +233,10 @@ contract BaseComposableCoWTest is Base, Merkle {
             Enum.Operation.Call,
             signers()
         );
+    }
+
+    function emptyProof() internal pure returns (ComposableCoW.Proof memory) {
+        return ComposableCoW.Proof({location: 0, data: hex""});
     }
 }
 

--- a/test/ComposableCoW.gat.t.sol
+++ b/test/ComposableCoW.gat.t.sol
@@ -32,7 +32,7 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         // Revert when the start time is before the current time
         vm.assume(currentTime < startTime);
 
-        GoodAfterTime.Data memory o = _gatTest(bytes(""));
+        GoodAfterTime.Data memory o = _gatTest(hex"");
         o.startTime = startTime;
 
         // Warp to the current time
@@ -50,7 +50,7 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         // Revert when the current balance is below the minimum balance
         vm.assume(currentBalance < minBalance);
 
-        GoodAfterTime.Data memory o = _gatTest(bytes(""));
+        GoodAfterTime.Data memory o = _gatTest(hex"");
         o.minSellBalance = minBalance;
 
         // Warp to the start time
@@ -117,7 +117,7 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
             startTime: startTime,
             endTime: endTime,
             allowPartialFill: allowPartialFill,
-            priceCheckerPayload: bytes(""),
+            priceCheckerPayload: hex"",
             appData: keccak256("GoodAfterTime")
         });
 
@@ -168,7 +168,7 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         // Guard against minBalance out of range
         currentBalance = bound(currentBalance, minBalance, type(uint256).max);
 
-        GoodAfterTime.Data memory o = _gatTest(bytes(""));
+        GoodAfterTime.Data memory o = _gatTest(hex"");
         o.startTime = startTime;
         o.endTime = endTime;
         o.minSellBalance = minBalance;
@@ -320,7 +320,7 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         );
 
         // 5. Execute the order
-        settle(address(safe1), bob, order, signature, bytes4(0));
+        settle(address(safe1), bob, order, signature, hex"");
     }
 
     // --- Helper functions ---

--- a/test/ComposableCoW.guards.t.sol
+++ b/test/ComposableCoW.guards.t.sol
@@ -54,7 +54,7 @@ contract ComposableCoWGuardsTest is BaseComposableCoWTest {
         // should work as there is no swap guard set
         (GPv2Order.Data memory order, bytes memory signature) =
             composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", proof);
-        settle(address(safe1), bob, order, signature, bytes4(0));
+        settle(address(safe1), bob, order, signature, hex"");
 
         // restores the state
         vm.revertTo(snapshot);
@@ -63,7 +63,9 @@ contract ComposableCoWGuardsTest is BaseComposableCoWTest {
         _setSwapGuard(address(safe1), evenSwapGuard);
 
         // should not be able to settle as the swap guard doesn't allow it
-        settle(address(safe1), bob, order, signature, ComposableCoW.SwapGuardRestricted.selector);
+        settle(
+            address(safe1), bob, order, signature, abi.encodeWithSelector(ComposableCoW.SwapGuardRestricted.selector)
+        );
 
         // should not be able to return the order as the swap guard doesn't allow it
         vm.expectRevert(ComposableCoW.SwapGuardRestricted.selector);
@@ -73,7 +75,7 @@ contract ComposableCoWGuardsTest is BaseComposableCoWTest {
         _setSwapGuard(address(safe1), oddSwapGuard);
 
         // should be able to settle as the swap guard allows it
-        settle(address(safe1), bob, order, signature, bytes4(0));
+        settle(address(safe1), bob, order, signature, hex"");
 
         // can remove the swap guard
         _setSwapGuard(address(safe1), ISwapGuard(address(0)));

--- a/test/ComposableCoW.guards.t.sol
+++ b/test/ComposableCoW.guards.t.sol
@@ -53,7 +53,7 @@ contract ComposableCoWGuardsTest is BaseComposableCoWTest {
 
         // should work as there is no swap guard set
         (GPv2Order.Data memory order, bytes memory signature) =
-            composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), proof);
+            composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", proof);
         settle(address(safe1), bob, order, signature, bytes4(0));
 
         // restores the state
@@ -67,7 +67,7 @@ contract ComposableCoWGuardsTest is BaseComposableCoWTest {
 
         // should not be able to return the order as the swap guard doesn't allow it
         vm.expectRevert(ComposableCoW.SwapGuardRestricted.selector);
-        composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), proof);
+        composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", proof);
 
         // should set the swap guard to the odd swap guard
         _setSwapGuard(address(safe1), oddSwapGuard);

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -66,7 +66,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         createOrder(stopLoss, 0x0, abi.encode(data));
 
         vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, STRIKE_NOT_REACHED));
-        stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
+        stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), hex"");
     }
 
     function test_RevertStrikePriceNotMet_fuzz(
@@ -101,7 +101,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         });
 
         vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, STRIKE_NOT_REACHED));
-        stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
+        stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), hex"");
     }
 
     function test_OracleNormalisesPrice_fuzz(
@@ -149,8 +149,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             maxTimeSinceLastOracleUpdate: 15 minutes
         });
 
-        GPv2Order.Data memory order =
-            stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
+        GPv2Order.Data memory order = stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), hex"");
         assertEq(address(order.sellToken), address(SELL_TOKEN));
         assertEq(address(order.buyToken), address(BUY_TOKEN));
         assertEq(order.sellAmount, 1 ether);
@@ -185,8 +184,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             maxTimeSinceLastOracleUpdate: 15 minutes
         });
 
-        GPv2Order.Data memory order =
-            stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
+        GPv2Order.Data memory order = stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), hex"");
         assertEq(address(order.sellToken), address(SELL_TOKEN));
         assertEq(address(order.buyToken), address(BUY_TOKEN));
         assertEq(order.sellAmount, 1 ether);
@@ -231,7 +229,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         });
 
         vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, ORACLE_STALE_PRICE));
-        stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
+        stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), hex"");
     }
 
     function test_OracleRevertOnInvalidPrice_fuzz(int256 invalidPrice, int256 validPrice) public {
@@ -260,7 +258,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         });
 
         vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, ORACLE_INVALID_PRICE));
-        stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
+        stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), hex"");
 
         // case where buy token price is invalid
 
@@ -268,7 +266,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         data.buyTokenPriceOracle = mockOracle(BUY_ORACLE, invalidPrice, block.timestamp, DEFAULT_DECIMALS);
 
         vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, ORACLE_INVALID_PRICE));
-        stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
+        stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), hex"");
     }
 
     function test_strikePriceMet_fuzz(int256 sellTokenOraclePrice, int256 buyTokenOraclePrice, int256 strike) public {
@@ -296,8 +294,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             maxTimeSinceLastOracleUpdate: 15 minutes
         });
 
-        GPv2Order.Data memory order =
-            stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
+        GPv2Order.Data memory order = stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), hex"");
         assertEq(address(order.sellToken), address(SELL_TOKEN));
         assertEq(address(order.buyToken), address(BUY_TOKEN));
         assertEq(order.sellAmount, 1 ether);
@@ -333,13 +330,12 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
 
         // 25 June 2023 18:59:59
         vm.warp(BLOCK_TIMESTAMP);
-        GPv2Order.Data memory order =
-            stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
+        GPv2Order.Data memory order = stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), hex"");
         assertEq(order.validTo, BLOCK_TIMESTAMP + 1); // 25 June 2023 19:00:00
 
         // 25 June 2023 19:00:00
         vm.warp(BLOCK_TIMESTAMP + 1);
-        order = stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
+        order = stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), hex"");
         assertEq(order.validTo, BLOCK_TIMESTAMP + 1 + 1 hours); // 25 June 2023 20:00:00
     }
 }

--- a/test/ComposableCoW.t.sol
+++ b/test/ComposableCoW.t.sol
@@ -51,7 +51,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
         uint256 snapshot = vm.snapshot();
 
         // should successfully execute the order
-        settle(address(safe1), bob, order, signature, bytes4(0));
+        settle(address(safe1), bob, order, signature, hex"");
 
         // restore the state
         vm.revertTo(snapshot);
@@ -93,7 +93,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
         uint256 snapshot = vm.snapshot();
 
         // should successfully execute the order
-        settle(address(safe1), bob, order, signature, bytes4(0));
+        settle(address(safe1), bob, order, signature, hex"");
 
         // restore the state
         vm.revertTo(snapshot);
@@ -207,7 +207,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
             composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", proof);
 
         // should successfully settle the order
-        settle(address(safe1), bob, order, signature, bytes4(0));
+        settle(address(safe1), bob, order, signature, hex"");
 
         // restores the state
         vm.revertTo(snapshot);
@@ -216,7 +216,9 @@ contract ComposableCoWTest is BaseComposableCoWTest {
         _remove(address(safe1), params);
 
         // should fail to settle the order as it has been removed
-        settle(address(safe1), bob, order, signature, ComposableCoW.SingleOrderNotAuthed.selector);
+        settle(
+            address(safe1), bob, order, signature, abi.encodeWithSelector(ComposableCoW.SingleOrderNotAuthed.selector)
+        );
     }
 
     /// @dev `BaseConditionalOrder` enforces that the order hash is valid

--- a/test/ComposableCoW.t.sol
+++ b/test/ComposableCoW.t.sol
@@ -13,12 +13,12 @@ contract ComposableCoWTest is BaseComposableCoWTest {
 
     /// @dev Can set the Merkle root for `owner`
     function test_setRoot_FuzzSetAndEmit(address owner, bytes32 root) public {
-        _setRoot(owner, root, ComposableCoW.Proof({location: 0, data: ""}));
+        _setRoot(owner, root, emptyProof());
     }
 
     function test_setRootWithContext_FuzzSetAndEmit(address owner, bytes32 root, bytes32 data) public {
         _setRootWithContext(
-            owner, root, ComposableCoW.Proof({location: 0, data: ""}), testContextValue, abi.encode(data)
+            owner, root, emptyProof(), testContextValue, abi.encode(data)
         );
     }
 
@@ -37,15 +37,15 @@ contract ComposableCoWTest is BaseComposableCoWTest {
 
         // should fail to validate the proof as root is still set bytes32(0)
         vm.expectRevert(ComposableCoW.ProofNotAuthed.selector);
-        composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), proof);
+        composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", proof);
 
         // should set the root correctly
-        ComposableCoW.Proof memory proofStruct = ComposableCoW.Proof({location: 0, data: ""});
+        ComposableCoW.Proof memory proofStruct = emptyProof();
         _setRoot(address(safe1), root, proofStruct);
 
         // should pass with the root correctly set
         (GPv2Order.Data memory order, bytes memory signature) =
-            composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), proof);
+            composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", proof);
 
         // save the state
         uint256 snapshot = vm.snapshot();
@@ -61,7 +61,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
 
         // should fail as the root is set to bytes32(0)
         vm.expectRevert(ComposableCoW.ProofNotAuthed.selector);
-        composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), proof);
+        composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", proof);
     }
 
     /**
@@ -79,15 +79,15 @@ contract ComposableCoWTest is BaseComposableCoWTest {
 
         // should fail to validate the proof as root is still set bytes32(0)
         vm.expectRevert(ComposableCoW.ProofNotAuthed.selector);
-        composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), proof);
+        composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", proof);
 
         // should set the root correctly
-        ComposableCoW.Proof memory proofStruct = ComposableCoW.Proof({location: 0, data: ""});
+        ComposableCoW.Proof memory proofStruct = emptyProof();
         _setRootWithContext(address(safe1), root, proofStruct, testContextValue, abi.encode(bytes32("testValue")));
 
         // should pass with the root correctly set
         (GPv2Order.Data memory order, bytes memory signature) =
-            composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), proof);
+            composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", proof);
 
         // save the state
         uint256 snapshot = vm.snapshot();
@@ -103,7 +103,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
 
         // should fail as the root is set to bytes32(0)
         vm.expectRevert(ComposableCoW.ProofNotAuthed.selector);
-        composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), proof);
+        composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", proof);
     }
 
     /// @dev Should disallow setting a handler that is address(0)
@@ -111,7 +111,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
         IConditionalOrder.ConditionalOrderParams memory params = IConditionalOrder.ConditionalOrderParams({
             handler: IConditionalOrder(address(0)),
             salt: keccak256("zero is invalid handler"),
-            staticInput: ""
+            staticInput: hex""
         });
 
         vm.expectRevert(ComposableCoW.InvalidHandler.selector);
@@ -194,7 +194,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
 
         // should fail to return the order as it is not authorized
         vm.expectRevert(ComposableCoW.SingleOrderNotAuthed.selector);
-        composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), proof);
+        composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", proof);
 
         // can create the order
         _create(address(safe1), params, true);
@@ -204,7 +204,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
 
         // order can be returned as it is authorized
         (GPv2Order.Data memory order, bytes memory signature) =
-            composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), proof);
+            composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", proof);
 
         // should successfully settle the order
         settle(address(safe1), bob, order, signature, bytes4(0));
@@ -268,7 +268,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
         });
 
         // should set the root
-        _setRoot(owner, root, ComposableCoW.Proof({location: 0, data: ""}));
+        _setRoot(owner, root, emptyProof());
 
         // should revert as the proof is invalid
         vm.expectRevert(ComposableCoW.ProofNotAuthed.selector);
@@ -279,7 +279,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
             keccak256("some domain separator"),
             bytes32(0), // typeHash isn't used
             abi.encode(getBlankOrder()),
-            abi.encode(ComposableCoW.PayloadStruct({proof: proof, params: params, offchainInput: bytes("")}))
+            abi.encode(ComposableCoW.PayloadStruct({proof: proof, params: params, offchainInput: hex""}))
         );
     }
 
@@ -307,7 +307,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
             keccak256("some domain separator"),
             bytes32(0), // typeHash isn't used
             abi.encode(getBlankOrder()),
-            abi.encode(ComposableCoW.PayloadStruct({proof: new bytes32[](0), params: params, offchainInput: bytes("")}))
+            abi.encode(ComposableCoW.PayloadStruct({proof: new bytes32[](0), params: params, offchainInput: hex""}))
         );
     }
 
@@ -318,7 +318,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
         IConditionalOrder.ConditionalOrderParams memory params = IConditionalOrder.ConditionalOrderParams({
             handler: IConditionalOrder(mirror),
             salt: keccak256("mirror"),
-            staticInput: bytes("")
+            staticInput: hex""
         });
 
         // should create a single order
@@ -326,7 +326,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
 
         // get a blank order
         GPv2Order.Data memory order = getBlankOrder();
-        bytes memory offchainInput = bytes("");
+        bytes memory offchainInput = hex"";
 
         // As we want to inspect the revert data, we need to do a low-level call.
         bytes memory cd = abi.encodeCall(
@@ -369,18 +369,15 @@ contract ComposableCoWTest is BaseComposableCoWTest {
     /// @dev `getTradeableOrderWithSignature` should revert if the interface is not supported
     function test_getTradeableOrderWithSignature_RevertInterfaceNotSupported() public {
         // use the mirror handler as it does not support the interface
-        IConditionalOrder.ConditionalOrderParams memory params = IConditionalOrder.ConditionalOrderParams({
-            handler: mirror,
-            salt: keccak256("mirror"),
-            staticInput: bytes("")
-        });
+        IConditionalOrder.ConditionalOrderParams memory params =
+            IConditionalOrder.ConditionalOrderParams({handler: mirror, salt: keccak256("mirror"), staticInput: hex""});
 
         // should create a single order
         _create(alice.addr, params, false);
 
         // should revert as the interface is not supported
         vm.expectRevert(ComposableCoW.InterfaceNotSupported.selector);
-        composableCow.getTradeableOrderWithSignature(alice.addr, params, bytes(""), new bytes32[](0));
+        composableCow.getTradeableOrderWithSignature(alice.addr, params, hex"", new bytes32[](0));
     }
 
     /// @dev `getTradeableOrderWithSignature` should revert if given an invalid proof
@@ -402,11 +399,11 @@ contract ComposableCoWTest is BaseComposableCoWTest {
         });
 
         // should set the root
-        _setRoot(owner, root, ComposableCoW.Proof({location: 0, data: ""}));
+        _setRoot(owner, root, emptyProof());
 
         // should revert as the proof is invalid
         vm.expectRevert(ComposableCoW.ProofNotAuthed.selector);
-        composableCow.getTradeableOrderWithSignature(owner, params, bytes(""), proof);
+        composableCow.getTradeableOrderWithSignature(owner, params, hex"", proof);
     }
 
     /// @dev `getTradeableOrderWithSignature` should revert if given an invalid single order
@@ -424,7 +421,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
 
         // should revert as the order has not been created
         vm.expectRevert(ComposableCoW.SingleOrderNotAuthed.selector);
-        composableCow.getTradeableOrderWithSignature(owner, params, bytes(""), new bytes32[](0));
+        composableCow.getTradeableOrderWithSignature(owner, params, hex"", new bytes32[](0));
     }
 
     /// @dev should return a valid payload for a safe

--- a/test/ComposableCoW.t.sol
+++ b/test/ComposableCoW.t.sol
@@ -17,9 +17,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
     }
 
     function test_setRootWithContext_FuzzSetAndEmit(address owner, bytes32 root, bytes32 data) public {
-        _setRootWithContext(
-            owner, root, emptyProof(), testContextValue, abi.encode(data)
-        );
+        _setRootWithContext(owner, root, emptyProof(), testContextValue, abi.encode(data));
     }
 
     /**

--- a/test/ComposableCoW.twap.t.sol
+++ b/test/ComposableCoW.twap.t.sol
@@ -109,7 +109,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
 
         vm.warp(block.timestamp + (FREQUENCY * (NUM_PARTS - 1)) + SPAN);
         vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.PollNever.selector, NOT_WITHIN_SPAN));
-        twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
+        twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), hex"");
     }
 
     /**
@@ -119,8 +119,12 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         TWAPOrder.Data memory o = _twapTestBundle(block.timestamp);
 
         vm.warp(block.timestamp + (FREQUENCY * (NUM_PARTS - 2)) + SPAN);
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.PollTryAtEpoch.selector, o.t0 + (FREQUENCY * (NUM_PARTS - 1)), NOT_WITHIN_SPAN));
-        twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IConditionalOrder.PollTryAtEpoch.selector, o.t0 + (FREQUENCY * (NUM_PARTS - 1)), NOT_WITHIN_SPAN
+            )
+        );
+        twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), hex"");
     }
 
     /**
@@ -192,13 +196,13 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         vm.warp(startTime);
 
         // Verify that the order is valid - this shouldn't revert
-        twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
+        twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), hex"");
 
         // Warp to current time
         vm.warp(currentTime);
 
         vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.PollTryAtEpoch.selector, startTime, BEFORE_TWAP_START));
-        twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
+        twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), hex"");
     }
 
     /**
@@ -218,13 +222,13 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         vm.warp(startTime);
 
         // Verify that the order is valid - this shouldn't revert
-        twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
+        twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), hex"");
 
         // Warp to expiry
         vm.warp(currentTime);
 
         vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.PollNever.selector, AFTER_TWAP_FINISH));
-        twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
+        twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), hex"");
     }
 
     /**
@@ -246,7 +250,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         vm.warp(startTime);
 
         // Verify that the order is valid - this shouldn't revert
-        twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
+        twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), hex"");
 
         // Warp to outside of the span
         vm.warp(currentTime);
@@ -254,7 +258,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         // Just check that it reverts, don't reproduce the whole logic for PollNever / PollAtEpoch
         // do that in a concrete tests.
         vm.expectRevert();
-        twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
+        twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), hex"");
     }
 
     function test_getTradeableOrder_FuzzRevertIfOrderBeforeBlockTimestamp(
@@ -272,9 +276,8 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         vm.warp(ctxBlockTimestamp);
 
         // Create the order - this signs the order and marks it as valid
-        IConditionalOrder.ConditionalOrderParams memory params = createOrderWithContext(
-            safe1, o, o.sellToken, o.partSellAmount * o.n, currentBlockTimestampFactory, bytes("")
-        );
+        IConditionalOrder.ConditionalOrderParams memory params =
+            createOrderWithContext(safe1, o, o.sellToken, o.partSellAmount * o.n, currentBlockTimestampFactory, hex"");
 
         assertEq(composableCow.cabinet(address(safe1), composableCow.hash(params)), bytes32(uint256(ctxBlockTimestamp)));
 
@@ -282,8 +285,10 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         vm.warp(currentTime);
 
         // The below should revert
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.PollTryAtEpoch.selector, ctxBlockTimestamp, BEFORE_TWAP_START));
-        composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), new bytes32[](0));
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.PollTryAtEpoch.selector, ctxBlockTimestamp, BEFORE_TWAP_START)
+        );
+        composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", new bytes32[](0));
     }
 
     function test_getTradeableOrder_FuzzRevertIfOrderAfterBlocktimestampValidity(
@@ -301,9 +306,8 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         vm.warp(ctxBlockTimestamp);
 
         // Create the order - this signs the order and marks it as valid
-        IConditionalOrder.ConditionalOrderParams memory params = createOrderWithContext(
-            safe1, o, o.sellToken, o.partSellAmount * o.n, currentBlockTimestampFactory, bytes("")
-        );
+        IConditionalOrder.ConditionalOrderParams memory params =
+            createOrderWithContext(safe1, o, o.sellToken, o.partSellAmount * o.n, currentBlockTimestampFactory, hex"");
 
         assertEq(composableCow.cabinet(address(safe1), composableCow.hash(params)), bytes32(uint256(ctxBlockTimestamp)));
 
@@ -312,7 +316,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
 
         // The below should revert
         vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.PollNever.selector, AFTER_TWAP_FINISH));
-        composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), new bytes32[](0));
+        composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", new bytes32[](0));
     }
 
     function test_getTradeableOrder_e2e_fuzz_WithContext(uint32 _blockTimestamp, uint256 currentTime) public {
@@ -332,15 +336,14 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         vm.warp(_blockTimestamp);
 
         // Create the order - this signs the order and marks it a valid
-        IConditionalOrder.ConditionalOrderParams memory params = createOrderWithContext(
-            safe1, o, o.sellToken, o.partSellAmount * o.n, currentBlockTimestampFactory, bytes("")
-        );
+        IConditionalOrder.ConditionalOrderParams memory params =
+            createOrderWithContext(safe1, o, o.sellToken, o.partSellAmount * o.n, currentBlockTimestampFactory, hex"");
 
         assertEq(composableCow.cabinet(address(safe1), composableCow.hash(params)), bytes32(uint256(_blockTimestamp)));
 
         // This should not revert
         (GPv2Order.Data memory part, bytes memory signature) =
-            composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), new bytes32[](0));
+            composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", new bytes32[](0));
 
         // Verify that the order is valid - this shouldn't revert
         assertTrue(
@@ -381,7 +384,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
 
         // This should not revert
         (GPv2Order.Data memory part, bytes memory signature) =
-            composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), new bytes32[](0));
+            composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", new bytes32[](0));
 
         // Verify that the order is valid - this shouldn't revert
         assertTrue(
@@ -410,8 +413,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         // Warp to the current time
         vm.warp(currentTime);
 
-        GPv2Order.Data memory order =
-            twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), bytes(""));
+        GPv2Order.Data memory order = twap.getTradeableOrder(address(0), address(0), bytes32(0), abi.encode(o), hex"");
         bytes32 domainSeparator = composableCow.domainSeparator();
 
         // Verify that the order is valid - this shouldn't revert
@@ -422,7 +424,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
             domainSeparator,
             bytes32(0),
             abi.encode(o),
-            bytes(""),
+            hex"",
             order
         );
     }
@@ -443,7 +445,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
 
         // 4. Get the order and signature
         (GPv2Order.Data memory order, bytes memory signature) =
-            composableCow.getTradeableOrderWithSignature(address(safe1), leaf, bytes(""), proof);
+            composableCow.getTradeableOrderWithSignature(address(safe1), leaf, hex"", proof);
 
         // 5. Execute the order
         settle(address(safe1), bob, order, signature, bytes4(0));
@@ -502,8 +504,9 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
         while (true) {
             // Simulate being called by the watch tower
 
-            try composableCow.getTradeableOrderWithSignature(address(safe1), params, bytes(""), new bytes32[](0))
-            returns (GPv2Order.Data memory order, bytes memory signature) {
+            try composableCow.getTradeableOrderWithSignature(address(safe1), params, hex"", new bytes32[](0)) returns (
+                GPv2Order.Data memory order, bytes memory signature
+            ) {
                 bytes32 orderDigest = GPv2Order.hash(order, settlement.domainSeparator());
                 if (
                     orderFills[orderDigest] == 0

--- a/test/ComposableCoW.twap.t.sol
+++ b/test/ComposableCoW.twap.t.sol
@@ -448,7 +448,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
             composableCow.getTradeableOrderWithSignature(address(safe1), leaf, hex"", proof);
 
         // 5. Execute the order
-        settle(address(safe1), bob, order, signature, bytes4(0));
+        settle(address(safe1), bob, order, signature, hex"");
     }
 
     /**
@@ -514,7 +514,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
                             == ERC1271.isValidSignature.selector
                 ) {
                     // Have a new order, so let's settle it
-                    settle(address(safe1), bob, order, signature, bytes4(0));
+                    settle(address(safe1), bob, order, signature, hex"");
 
                     orderFills[orderDigest] = 1;
                     totalFills++;

--- a/test/helpers/CoWProtocol.t.sol
+++ b/test/helpers/CoWProtocol.t.sol
@@ -98,14 +98,14 @@ abstract contract CoWProtocol is Test, Tokens {
      * @param counterParty the account that is on the other side of the trade
      * @param order the order to settle
      * @param bundleBytes the ERC-1271 bundle for the order
-     * @param _revertSelector the selector to revert with if the order is invalid
+     * @param revertData the data returned by the function on revert
      */
     function settle(
         address who,
         TestAccount memory counterParty,
         GPv2Order.Data memory order,
         bytes memory bundleBytes,
-        bytes4 _revertSelector
+        bytes memory revertData
     ) internal {
         // Generate counter party's order
         GPv2Order.Data memory counterOrder = GPv2Order.Data({
@@ -179,10 +179,10 @@ abstract contract CoWProtocol is Test, Tokens {
 
         // finally we can execute the settlement
         vm.prank(solver.addr);
-        if (_revertSelector == bytes4(0)) {
+        if (revertData.length == 0) {
             settlement.settle(tokens, clearingPrices, trades, interactions);
         } else {
-            vm.expectRevert(_revertSelector);
+            vm.expectRevert(revertData);
             settlement.settle(tokens, clearingPrices, trades, interactions);
         }
     }


### PR DESCRIPTION
# Description
The current test suite only allows for testing settlements that may revert with only a `4bytes` selector (ie. no parameterized). This PR remedies that.

# Changes

- [x] Abstract revert data can be asserted with `settle` in the test harness.
- [x] Standardises the use of `hex""` for hex literal strings / empty bytes.
- [x] Gardening to dry some test of the test harness.

## How to test

1. `forge test -vvv --optimizer-runs 200 --no-match-test "fork|simulate" --fuzz-seed 672679878`