### PR TITLE
chore: fix repo imports and add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+	"name": "Foundry + Node",
+	"image": "mcr.microsoft.com/devcontainers/base:0",
+	"features": {
+		"ghcr.io/nlordell/features/foundry": {},
+		"ghcr.io/devcontainers/features/node:1": {}
+	},
+	"customizations": {
+		"vscode" : {
+			"extensions": [
+				"JuanBlanco.solidity"
+			]
+		}
+	}
+}

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,3 +12,7 @@
 	path = lib/cowprotocol
 	url = https://github.com/cowprotocol/contracts
 	branch = main
+[submodule "lib/safe"]
+	path = lib/safe
+	url = https://github.com/cowdao-grants/extensible-fallback-handler
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,7 @@
 [submodule "lib/@openzeppelin"]
 	path = lib/@openzeppelin
 	url = https://github.com/openzeppelin/openzeppelin-contracts
+[submodule "lib/cowprotocol"]
+	path = lib/cowprotocol
+	url = https://github.com/cowprotocol/contracts
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,9 +5,6 @@
 [submodule "lib/murky"]
 	path = lib/murky
 	url = https://github.com/dmfxyz/murky
-[submodule "lib/safe"]
-	path = lib/safe
-	url = https://github.com/rndlabs/safe-contracts
 [submodule "lib/@openzeppelin"]
 	path = lib/@openzeppelin
 	url = https://github.com/openzeppelin/openzeppelin-contracts

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,15 +2,6 @@
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
 	branch = v1.5.3
-[submodule "lib/cowprotocol"]
-	path = lib/cowprotocol
-	url = https://github.com/rndlabs/cowswap-contracts
-[submodule "lib/balancer"]
-	path = lib/balancer
-	url = https://github.com/rndlabs/balancer
-[submodule "lib/canonical-weth"]
-	path = lib/canonical-weth
-	url = https://github.com/rndlabs/canonical-weth
 [submodule "lib/murky"]
 	path = lib/murky
 	url = https://github.com/dmfxyz/murky

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,14 +1,7 @@
-@openzeppelin/=lib/@openzeppelin/contracts/
-@openzeppelin/contracts/=lib/@openzeppelin/contracts/
-balancer/=lib/balancer/src/
-canonical-weth/=lib/canonical-weth/src/
-cowprotocol/=lib/cowprotocol/src/contracts/
+@openzeppelin/=lib/@openzeppelin/
 ds-test/=lib/forge-std/lib/ds-test/src/
 erc4626-tests/=lib/@openzeppelin/lib/erc4626-tests/
 forge-std/=lib/forge-std/src/
-helpers/=lib/balancer/src/lib/helpers/
-math/=lib/balancer/src/lib/math/
 murky/=lib/murky/src/
 openzeppelin-contracts/=lib/murky/lib/openzeppelin-contracts/
-openzeppelin/=lib/@openzeppelin/contracts/
 safe/=lib/safe/contracts/

--- a/script/deploy_AnvilStack.s.sol
+++ b/script/deploy_AnvilStack.s.sol
@@ -1,25 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "forge-std/Script.sol";
+import {Script, console} from "forge-std/Script.sol";
 
 // CoW Protocol
-import {IWETH, WETH9} from "canonical-weth/WETH9.sol";
-import {IAuthorizer, Authorizer} from "balancer/vault/Authorizer.sol";
-import {Vault} from "balancer/vault/Vault.sol";
-import {IVault as GPv2IVault} from "cowprotocol/interfaces/IVault.sol";
-import "cowprotocol/GPv2Settlement.sol";
-import "cowprotocol/GPv2AllowListAuthentication.sol";
-import "cowprotocol/interfaces/GPv2Authentication.sol";
+import {IVault} from "cowprotocol/contracts/interfaces/IVault.sol";
+import {GPv2Settlement} from "cowprotocol/contracts/GPv2Settlement.sol";
+import {GPv2AllowListAuthentication} from "cowprotocol/contracts/GPv2AllowListAuthentication.sol";
+import {GPv2Authentication} from "cowprotocol/contracts/interfaces/GPv2Authentication.sol";
 
 // Safe contracts
 import {Safe} from "safe/Safe.sol";
 import {Enum} from "safe/common/Enum.sol";
-import "safe/proxies/SafeProxyFactory.sol";
+import {SafeProxyFactory, SafeProxy} from "safe/proxies/SafeProxyFactory.sol";
 import {CompatibilityFallbackHandler} from "safe/handler/CompatibilityFallbackHandler.sol";
 import {MultiSend} from "safe/libraries/MultiSend.sol";
 import {SignMessageLib} from "safe/libraries/SignMessageLib.sol";
-import "safe/handler/ExtensibleFallbackHandler.sol";
+import {ExtensibleFallbackHandler} from "safe/handler/ExtensibleFallbackHandler.sol";
 import {SafeLib} from "../test/libraries/SafeLib.t.sol";
 
 // Composable CoW
@@ -35,10 +32,8 @@ contract DeployAnvilStack is Script {
     uint256 constant BUFFER_PERIOD_DURATION = 2592000;
 
     // --- cow protocol contract stack
-    Authorizer public authorizer;
-    GPv2IVault public vault;
+    IVault public vault;
     GPv2Settlement public settlement;
-    WETH9 public weth;
     address public relayer;
 
     // --- safe contract stack
@@ -95,37 +90,14 @@ contract DeployAnvilStack is Script {
     }
 
     function deployCowProtocolStack(address all) internal {
-        // deploy the WETH contract
-        weth = new WETH9();
-
-        authorizer = new Authorizer(all);
-
-        // deploy the Balancer vault
-        // parameters taken from mainnet initialization:
-        //   Arg [0] : authorizer (address): 0xA331D84eC860Bf466b4CdCcFb4aC09a1B43F3aE6
-        //   Arg [1] : weth (address): 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
-        //   Arg [2] : pauseWindowDuration (uint256): 7776000
-        //   Arg [3] : bufferPeriodDuration (uint256): 2592000
-        vault = GPv2IVault(
-            address(
-                new Vault(
-                    authorizer,
-                    weth,
-                    PAUSE_WINDOW_DURATION,
-                    BUFFER_PERIOD_DURATION
-                )
-            )
-        );
+        vault = IVault(makeAddr("fakeVault"));
 
         // deploy the allow list manager
         GPv2AllowListAuthentication allowList = new GPv2AllowListAuthentication();
         allowList.initializeManager(all);
 
         /// @dev the settlement contract is the main entry point for the CoW Protocol
-        settlement = new GPv2Settlement(
-            allowList,
-            vault
-        );
+        settlement = new GPv2Settlement(allowList, vault);
 
         /// @dev the relayer is the account authorized to spend the user's tokens
         relayer = address(settlement.vaultRelayer());

--- a/script/deploy_ComposableCoW.s.sol
+++ b/script/deploy_ComposableCoW.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "forge-std/Script.sol";
+import {Script} from "forge-std/Script.sol";
 
 import {ComposableCoW} from "../src/ComposableCoW.sol";
 

--- a/script/deploy_ExtensibleFallbackHandler.s.sol
+++ b/script/deploy_ExtensibleFallbackHandler.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "forge-std/Script.sol";
+import {Script} from "forge-std/Script.sol";
 
 import {ExtensibleFallbackHandler} from "safe/handler/ExtensibleFallbackHandler.sol";
 

--- a/script/deploy_OrderTypes.s.sol
+++ b/script/deploy_OrderTypes.s.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "forge-std/Script.sol";
+import {Script} from "forge-std/Script.sol";
 
-import "../src/ComposableCoW.sol";
+import {ComposableCoW} from "../src/ComposableCoW.sol";
 
 import {TWAP} from "../src/types/twap/TWAP.sol";
 import {GoodAfterTime} from "../src/types/GoodAfterTime.sol";

--- a/script/deploy_ProdStack.s.sol
+++ b/script/deploy_ProdStack.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "forge-std/Script.sol";
+import {Script} from "forge-std/Script.sol";
 
 // ExtensibleFallbackHandler
 import {ExtensibleFallbackHandler} from "../lib/safe/contracts/handler/ExtensibleFallbackHandler.sol";

--- a/script/deploy_ValueFactories.s.sol
+++ b/script/deploy_ValueFactories.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "forge-std/Script.sol";
+import {Script} from "forge-std/Script.sol";
 
 import {CurrentBlockTimestampFactory} from "../src/value_factories/CurrentBlockTimestampFactory.sol";
 

--- a/script/submit_SingleOrder.s.sol
+++ b/script/submit_SingleOrder.s.sol
@@ -1,26 +1,23 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "forge-std/Script.sol";
+import {Script} from "forge-std/Script.sol";
 
-import {IERC20, IERC20Metadata} from "@openzeppelin/interfaces/IERC20Metadata.sol";
+import {IERC20} from "cowprotocol/contracts/interfaces/IERC20.sol";
 
 // Safe contracts
 import {Safe} from "safe/Safe.sol";
 import {Enum} from "safe/common/Enum.sol";
-import "safe/proxies/SafeProxyFactory.sol";
+import {SafeProxyFactory} from "safe/proxies/SafeProxyFactory.sol";
 import {CompatibilityFallbackHandler} from "safe/handler/CompatibilityFallbackHandler.sol";
 import {MultiSend} from "safe/libraries/MultiSend.sol";
 import {SignMessageLib} from "safe/libraries/SignMessageLib.sol";
-import "safe/handler/ExtensibleFallbackHandler.sol";
+import {ExtensibleFallbackHandler} from "safe/handler/ExtensibleFallbackHandler.sol";
 import {SafeLib} from "../test/libraries/SafeLib.t.sol";
 
 // Composable CoW
-import "../src/ComposableCoW.sol";
-import "../src/types/twap/TWAP.sol";
-import {GoodAfterTime} from "../src/types/GoodAfterTime.sol";
-import {PerpetualStableSwap} from "../src/types/PerpetualStableSwap.sol";
-import {TradeAboveThreshold} from "../src/types/TradeAboveThreshold.sol";
+import {IConditionalOrder, ComposableCoW} from "../src/ComposableCoW.sol";
+import {TWAP, TWAPOrder} from "../src/types/twap/TWAP.sol";
 
 /**
  * @title Submit a single order to ComposableCoW

--- a/src/BaseConditionalOrder.sol
+++ b/src/BaseConditionalOrder.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
-import {GPv2Order} from "cowprotocol/libraries/GPv2Order.sol";
+import {GPv2Order, IERC20} from "cowprotocol/contracts/libraries/GPv2Order.sol";
 
-import "./interfaces/IConditionalOrder.sol";
+import {IERC165, IConditionalOrder, IConditionalOrderGenerator} from "./interfaces/IConditionalOrder.sol";
 
 // --- error strings
 /// @dev This error is returned by the `verify` function if the *generated* order hash does not match

--- a/src/ComposableCoW.sol
+++ b/src/ComposableCoW.sol
@@ -2,12 +2,18 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import {MerkleProof} from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
-import "safe/handler/ExtensibleFallbackHandler.sol";
+import {
+    ExtensibleFallbackHandler,
+    ERC1271,
+    ISignatureVerifierMuxer,
+    ISafeSignatureVerifier,
+    Safe
+} from "safe/handler/ExtensibleFallbackHandler.sol";
 
-import "./interfaces/IConditionalOrder.sol";
-import "./interfaces/ISwapGuard.sol";
-import "./interfaces/IValueFactory.sol";
-import "./vendored/CoWSettlement.sol";
+import {IConditionalOrder, IConditionalOrderGenerator, GPv2Order} from "./interfaces/IConditionalOrder.sol";
+import {ISwapGuard} from "./interfaces/ISwapGuard.sol";
+import {IValueFactory} from "./interfaces/IValueFactory.sol";
+import {CoWSettlement} from "./vendored/CoWSettlement.sol";
 
 /**
  * @title ComposableCoW - A contract that allows users to create multiple conditional orders

--- a/src/ERC1271Forwarder.sol
+++ b/src/ERC1271Forwarder.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {ERC1271} from "safe/handler/extensible/SignatureVerifierMuxer.sol";
-import {GPv2Order} from "cowprotocol/libraries/GPv2Order.sol";
+import {ERC1271, Safe} from "safe/handler/extensible/SignatureVerifierMuxer.sol";
+import {GPv2Order} from "cowprotocol/contracts/libraries/GPv2Order.sol";
 
-import "./ComposableCoW.sol";
+import {ComposableCoW} from "./ComposableCoW.sol";
 
 /**
  * @title ERC1271 Forwarder - An abstract contract that implements ERC1271 forwarding to ComposableCoW

--- a/src/guards/BaseSwapGuard.sol
+++ b/src/guards/BaseSwapGuard.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "../interfaces/ISwapGuard.sol";
+import {ISwapGuard, IERC165} from "../interfaces/ISwapGuard.sol";
 
 /**
  * @title An abstract base contract for Swap Guards to inherit from

--- a/src/guards/ReceiverLock.sol
+++ b/src/guards/ReceiverLock.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "./BaseSwapGuard.sol";
+import {BaseSwapGuard} from "./BaseSwapGuard.sol";
+import {IConditionalOrder, GPv2Order} from "../interfaces/IConditionalOrder.sol";
 
 /**
  * @title A Swap Guard that only allows orders with a receiver of 0x0 (ie. self)

--- a/src/interfaces/IConditionalOrder.sol
+++ b/src/interfaces/IConditionalOrder.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {GPv2Order} from "cowprotocol/libraries/GPv2Order.sol";
-import {GPv2Interaction} from "cowprotocol/libraries/GPv2Interaction.sol";
+import {GPv2Order} from "cowprotocol/contracts/libraries/GPv2Order.sol";
+import {GPv2Interaction} from "cowprotocol/contracts/libraries/GPv2Interaction.sol";
 import {IERC165} from "safe/interfaces/IERC165.sol";
 
 /**

--- a/src/interfaces/ISwapGuard.sol
+++ b/src/interfaces/ISwapGuard.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {GPv2Order} from "cowprotocol/libraries/GPv2Order.sol";
 import {IERC165} from "safe/interfaces/IERC165.sol";
 
-import {IConditionalOrder} from "./IConditionalOrder.sol";
+import {IConditionalOrder, GPv2Order} from "./IConditionalOrder.sol";
 
 /**
  * @title SwapGuard Interface - Restrict CoW Protocol settlement for an account using `ComposableCoW`.

--- a/src/types/GoodAfterTime.sol
+++ b/src/types/GoodAfterTime.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {IERC20} from "@openzeppelin/interfaces/IERC20.sol";
-import {SafeCast} from "@openzeppelin/utils/math/SafeCast.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
-import "../vendored/Milkman.sol";
-import "../BaseConditionalOrder.sol";
+import {IExpectedOutCalculator} from "../vendored/Milkman.sol";
+import {IERC20, IConditionalOrder, GPv2Order, BaseConditionalOrder} from "../BaseConditionalOrder.sol";
 import {ConditionalOrdersUtilsLib as Utils} from "./ConditionalOrdersUtilsLib.sol";
 
 // --- error strings

--- a/src/types/PerpetualStableSwap.sol
+++ b/src/types/PerpetualStableSwap.sol
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
-import {IERC20, IERC20Metadata} from "@openzeppelin/interfaces/IERC20Metadata.sol";
-
-import "../BaseConditionalOrder.sol";
+import {
+    IERC20,
+    GPv2Order,
+    IConditionalOrder,
+    IConditionalOrderGenerator,
+    BaseConditionalOrder
+} from "../BaseConditionalOrder.sol";
 import {ConditionalOrdersUtilsLib as Utils} from "./ConditionalOrdersUtilsLib.sol";
 
 // --- error strings
@@ -84,8 +88,8 @@ contract PerpetualStableSwap is BaseConditionalOrder {
         view
         returns (BuySellData memory buySellData)
     {
-        IERC20Metadata tokenA = IERC20Metadata(address(data.tokenA));
-        IERC20Metadata tokenB = IERC20Metadata(address(data.tokenB));
+        IERC20 tokenA = IERC20(address(data.tokenA));
+        IERC20 tokenB = IERC20(address(data.tokenB));
         uint256 balanceA = tokenA.balanceOf(owner);
         uint256 balanceB = tokenB.balanceOf(owner);
 
@@ -106,7 +110,7 @@ contract PerpetualStableSwap is BaseConditionalOrder {
         }
     }
 
-    function convertAmount(IERC20Metadata srcToken, uint256 srcAmount, IERC20Metadata destToken)
+    function convertAmount(IERC20 srcToken, uint256 srcAmount, IERC20 destToken)
         internal
         view
         returns (uint256 destAmount)

--- a/src/types/StopLoss.sol
+++ b/src/types/StopLoss.sol
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {IERC20} from "@openzeppelin/interfaces/IERC20.sol";
-
-import "../BaseConditionalOrder.sol";
-import "../interfaces/IAggregatorV3Interface.sol";
+import {IERC20, GPv2Order, IConditionalOrder, BaseConditionalOrder} from "../BaseConditionalOrder.sol";
+import {IAggregatorV3Interface} from "../interfaces/IAggregatorV3Interface.sol";
 import {ConditionalOrdersUtilsLib as Utils} from "./ConditionalOrdersUtilsLib.sol";
 
 // --- error strings

--- a/src/types/TradeAboveThreshold.sol
+++ b/src/types/TradeAboveThreshold.sol
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
-import {IERC20} from "@openzeppelin/interfaces/IERC20.sol";
-
-import "../BaseConditionalOrder.sol";
+import {
+    IERC20,
+    GPv2Order,
+    IConditionalOrder,
+    IConditionalOrderGenerator,
+    BaseConditionalOrder
+} from "../BaseConditionalOrder.sol";
 import {ConditionalOrdersUtilsLib as Utils} from "./ConditionalOrdersUtilsLib.sol";
 
 // --- error strings

--- a/src/types/twap/TWAP.sol
+++ b/src/types/twap/TWAP.sol
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "../../ComposableCoW.sol";
+import {ComposableCoW} from "../../ComposableCoW.sol";
 
-import "../../BaseConditionalOrder.sol";
+import {
+    IConditionalOrder,
+    IConditionalOrderGenerator,
+    GPv2Order,
+    BaseConditionalOrder
+} from "../../BaseConditionalOrder.sol";
 import {TWAPOrder} from "./libraries/TWAPOrder.sol";
 
 // --- error strings

--- a/src/types/twap/libraries/TWAPOrder.sol
+++ b/src/types/twap/libraries/TWAPOrder.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {IERC20, IERC20Metadata} from "@openzeppelin/interfaces/IERC20Metadata.sol";
-import {SafeCast} from "@openzeppelin/utils/math/SafeCast.sol";
-import {GPv2Order} from "cowprotocol/libraries/GPv2Order.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {IERC20, GPv2Order} from "cowprotocol/contracts/libraries/GPv2Order.sol";
 
 import {IConditionalOrder} from "../../../interfaces/IConditionalOrder.sol";
 import {TWAPOrderMathLib} from "./TWAPOrderMathLib.sol";

--- a/src/vendored/Milkman.sol
+++ b/src/vendored/Milkman.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
-import {IERC20} from "@openzeppelin/interfaces/IERC20.sol";
+import {IERC20} from "cowprotocol/contracts/interfaces/IERC20.sol";
 
 interface IExpectedOutCalculator {
     function getExpectedOut(uint256 _amountIn, IERC20 _fromToken, IERC20 _toToken, bytes calldata _data)

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
 import {TestAccount, TestAccountLib} from "./libraries/TestAccountLib.t.sol";
 
-import "./helpers/CoWProtocol.t.sol";
-import "./helpers/Safe.t.sol";
+import {CoWProtocol} from "./helpers/CoWProtocol.t.sol";
+import {Safe, SafeHelper, SafeLib} from "./helpers/Safe.t.sol";
 
 abstract contract Base is Test, SafeHelper, CoWProtocol {
     using TestAccountLib for TestAccount[];

--- a/test/ComposableCoW.base.t.sol
+++ b/test/ComposableCoW.base.t.sol
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "forge-std/Test.sol";
-
-import {IERC20, IERC20Metadata} from "@openzeppelin/interfaces/IERC20Metadata.sol";
 import {Merkle} from "murky/Merkle.sol";
 
-import "safe/Safe.sol";
+import {Safe, IERC165, Enum} from "safe/Safe.sol";
 
 // Testing Libraries
 import {Base} from "./Base.t.sol";
@@ -14,7 +11,7 @@ import {TestAccount, TestAccountLib} from "./libraries/TestAccountLib.t.sol";
 import {SafeLib} from "./libraries/SafeLib.t.sol";
 import {ComposableCoWLib} from "./libraries/ComposableCoWLib.t.sol";
 
-import "../src/BaseConditionalOrder.sol";
+import {IConditionalOrder, IERC20, BaseConditionalOrder, INVALID_HASH} from "../src/BaseConditionalOrder.sol";
 import {BaseSwapGuard} from "../src/guards/BaseSwapGuard.sol";
 
 import {TWAP, TWAPOrder} from "../src/types/twap/TWAP.sol";
@@ -24,7 +21,7 @@ import {ReceiverLock} from "../src/guards/ReceiverLock.sol";
 
 import {IValueFactory} from "../src/interfaces/IValueFactory.sol";
 
-import "../src/ComposableCoW.sol";
+import {ISwapGuard, ComposableCoW, GPv2Order} from "../src/ComposableCoW.sol";
 
 contract BaseComposableCoWTest is Base, Merkle {
     using ComposableCoWLib for IConditionalOrder.ConditionalOrderParams;

--- a/test/ComposableCoW.forwarder.t.sol
+++ b/test/ComposableCoW.forwarder.t.sol
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "./ComposableCoW.base.t.sol";
+import {
+    GPv2Order,
+    IConditionalOrder,
+    BaseComposableCoWTest,
+    TestNonSafeWallet,
+    ERC1271Forwarder
+} from "./ComposableCoW.base.t.sol";
 
 contract ComposableCoWForwarderTest is BaseComposableCoWTest {
     function setUp() public virtual override(BaseComposableCoWTest) {

--- a/test/ComposableCoW.gat.t.sol
+++ b/test/ComposableCoW.gat.t.sol
@@ -3,9 +3,24 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import {ERC1271} from "safe/handler/extensible/SignatureVerifierMuxer.sol";
 
-import "./ComposableCoW.base.t.sol";
+import {
+    IERC20,
+    GPv2Order,
+    IConditionalOrder,
+    Safe,
+    SafeLib,
+    BaseComposableCoWTest,
+    ComposableCoW,
+    ComposableCoWLib
+} from "./ComposableCoW.base.t.sol";
 
-import "../src/types/GoodAfterTime.sol";
+import {
+    IExpectedOutCalculator,
+    GoodAfterTime,
+    TOO_EARLY,
+    BALANCE_INSUFFICIENT,
+    PRICE_CHECKER_FAILED
+} from "../src/types/GoodAfterTime.sol";
 
 contract ComposableCoWGatTest is BaseComposableCoWTest {
     using ComposableCoWLib for IConditionalOrder.ConditionalOrderParams[];
@@ -189,9 +204,8 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
 
         // Verify that the order is valid - this shouldn't revert
         assertTrue(
-            ExtensibleFallbackHandler(address(safe1)).isValidSignature(
-                GPv2Order.hash(order, settlement.domainSeparator()), signature
-            ) == ERC1271.isValidSignature.selector
+            ERC1271(address(safe1)).isValidSignature(GPv2Order.hash(order, settlement.domainSeparator()), signature)
+                == ERC1271.isValidSignature.selector
         );
     }
 
@@ -238,9 +252,8 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
 
         // Verify that the order is valid - this shouldn't revert
         assertTrue(
-            ExtensibleFallbackHandler(address(safe1)).isValidSignature(
-                GPv2Order.hash(order, settlement.domainSeparator()), signature
-            ) == ERC1271.isValidSignature.selector
+            ERC1271(address(safe1)).isValidSignature(GPv2Order.hash(order, settlement.domainSeparator()), signature)
+                == ERC1271.isValidSignature.selector
         );
     }
 

--- a/test/ComposableCoW.guards.t.sol
+++ b/test/ComposableCoW.guards.t.sol
@@ -1,7 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "./ComposableCoW.base.t.sol";
+import {ERC1271} from "safe/handler/extensible/SignatureVerifierMuxer.sol";
+
+import {
+    IERC165,
+    IConditionalOrder,
+    GPv2Order,
+    ComposableCoW,
+    BaseComposableCoWTest,
+    ISwapGuard,
+    TestSwapGuard,
+    ReceiverLock
+} from "./ComposableCoW.base.t.sol";
 
 contract ComposableCoWGuardsTest is BaseComposableCoWTest {
     function setUp() public virtual override(BaseComposableCoWTest) {
@@ -121,6 +132,6 @@ contract ComposableCoWGuardsTest is BaseComposableCoWTest {
 
         // should revert as the receiver is not the safe
         vm.expectRevert(ComposableCoW.SwapGuardRestricted.selector);
-        ExtensibleFallbackHandler(address(safe1)).isValidSignature(GPv2Order.hash(order, domainSeparator), signature);
+        ERC1271(address(safe1)).isValidSignature(GPv2Order.hash(order, domainSeparator), signature);
     }
 }

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {IERC20Metadata} from "@openzeppelin/interfaces/IERC20Metadata.sol";
-
-import "./ComposableCoW.base.t.sol";
-import "../src/interfaces/IAggregatorV3Interface.sol";
-import "../src/types/StopLoss.sol";
+import {IERC20, GPv2Order, IConditionalOrder, BaseComposableCoWTest} from "./ComposableCoW.base.t.sol";
+import {IAggregatorV3Interface} from "../src/interfaces/IAggregatorV3Interface.sol";
+import {StopLoss, STRIKE_NOT_REACHED, ORACLE_STALE_PRICE, ORACLE_INVALID_PRICE} from "../src/types/StopLoss.sol";
 
 contract ComposableCoWStopLossTest is BaseComposableCoWTest {
-    IERC20Metadata immutable SELL_TOKEN = IERC20Metadata(address(0x1));
-    IERC20Metadata immutable BUY_TOKEN = IERC20Metadata(address(0x2));
+    IERC20 immutable SELL_TOKEN = IERC20(address(0x1));
+    IERC20 immutable BUY_TOKEN = IERC20(address(0x2));
     address constant SELL_ORACLE = address(0x3);
     address constant BUY_ORACLE = address(0x4);
     bytes32 constant APP_DATA = bytes32(0x0);
@@ -38,8 +36,8 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         vm.mockCall(mock, abi.encodeWithSelector(iface.decimals.selector), abi.encode(decimals));
     }
 
-    function mockToken(IERC20Metadata token, uint8 decimals) internal returns (IERC20Metadata iface) {
-        iface = IERC20Metadata(token);
+    function mockToken(IERC20 token, uint8 decimals) internal returns (IERC20 iface) {
+        iface = IERC20(token);
         vm.mockCall(address(token), abi.encodeWithSelector(iface.decimals.selector), abi.encode(decimals));
     }
 
@@ -127,10 +125,10 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             buyToken: mockToken(BUY_TOKEN, buyTokenERC20Decimals),
             sellTokenPriceOracle: mockOracle(
                 SELL_ORACLE, int256(1834 * (10 ** sellTokenOracleDecimals)), block.timestamp, sellTokenOracleDecimals
-                ),
+            ),
             buyTokenPriceOracle: mockOracle(
                 BUY_ORACLE, int256(1 * (10 ** buyTokenOracleDecimals)), block.timestamp, buyTokenOracleDecimals
-                ),
+            ),
             strike: int256(
                 1900
                     * (
@@ -138,7 +136,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
                             ? (10 ** (sellTokenERC20Decimals - buyTokenERC20Decimals + 18))
                             : (10 ** (buyTokenERC20Decimals - sellTokenERC20Decimals + 18))
                     )
-                ), // Strike price is to 18 decimals, base / quote. ie. 1900_000_000_000_000_000_000 = 1900 USDC/ETH
+            ), // Strike price is to 18 decimals, base / quote. ie. 1900_000_000_000_000_000_000 = 1900 USDC/ETH
             sellAmount: 1 ether,
             buyAmount: 1,
             appData: APP_DATA,

--- a/test/ComposableCoW.t.sol
+++ b/test/ComposableCoW.t.sol
@@ -1,7 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "./ComposableCoW.base.t.sol";
+import {ERC1271} from "safe/handler/extensible/SignatureVerifierMuxer.sol";
+
+import {
+    IConditionalOrder,
+    GPv2Order,
+    ComposableCoW,
+    ComposableCoWLib,
+    INVALID_HASH,
+    BaseComposableCoWTest,
+    Safe,
+    TestNonSafeWallet
+} from "./ComposableCoW.base.t.sol";
 
 contract ComposableCoWTest is BaseComposableCoWTest {
     using ComposableCoWLib for IConditionalOrder.ConditionalOrderParams[];
@@ -340,7 +351,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
                 abi.encode(order),
                 abi.encode(
                     ComposableCoW.PayloadStruct({proof: new bytes32[](0), params: params, offchainInput: offchainInput})
-                    )
+                )
             )
         );
 
@@ -442,9 +453,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
 
         // order should be valid by using the `isValidSignature` function on the safe
         assertEq(
-            ExtensibleFallbackHandler(address(safe1)).isValidSignature(
-                GPv2Order.hash(order, composableCow.domainSeparator()), signature
-            ),
+            ERC1271(address(safe1)).isValidSignature(GPv2Order.hash(order, composableCow.domainSeparator()), signature),
             ERC1271.isValidSignature.selector
         );
     }

--- a/test/helpers/CoWProtocol.t.sol
+++ b/test/helpers/CoWProtocol.t.sol
@@ -1,21 +1,23 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 
-import {IWETH, WETH9} from "canonical-weth/WETH9.sol";
-
-import {IAuthorizer, Authorizer} from "balancer/vault/Authorizer.sol";
-import {Vault} from "balancer/vault/Vault.sol";
-
-import {IVault as GPv2IVault} from "cowprotocol/interfaces/IVault.sol";
-import "cowprotocol/GPv2Settlement.sol";
-import "cowprotocol/GPv2AllowListAuthentication.sol";
-import "cowprotocol/interfaces/GPv2Authentication.sol";
+import {IVault} from "cowprotocol/contracts/interfaces/IVault.sol";
+import {
+    IERC20,
+    GPv2Settlement,
+    GPv2Order,
+    GPv2Trade,
+    GPv2Interaction,
+    GPv2Signing
+} from "cowprotocol/contracts/GPv2Settlement.sol";
+import {GPv2AllowListAuthentication} from "cowprotocol/contracts/GPv2AllowListAuthentication.sol";
+import {GPv2Authentication} from "cowprotocol/contracts/interfaces/GPv2Authentication.sol";
 
 import {GPv2TradeEncoder} from "../vendored/GPv2TradeEncoder.sol";
 import {TestAccount, TestAccountLib} from "../libraries/TestAccountLib.t.sol";
-import {IERC20, Tokens} from "./Tokens.t.sol";
+import {Tokens} from "./Tokens.t.sol";
 
 /**
  * @title CoW Protocol - A helper contract for local integration testing with CoW Protocol.
@@ -29,9 +31,7 @@ abstract contract CoWProtocol is Test, Tokens {
     uint256 constant BUFFER_PERIOD_DURATION = 2592000;
 
     // --- contracts
-    IWETH public weth;
-    IAuthorizer public authorizer;
-    GPv2IVault public vault;
+    IVault public vault;
     GPv2Settlement public settlement;
 
     // --- accounts
@@ -39,10 +39,6 @@ abstract contract CoWProtocol is Test, Tokens {
     TestAccount solver;
 
     address public relayer;
-
-    constructor() {
-        weth = new WETH9();
-    }
 
     /**
      * @dev Sets up the CoW Protocol test environment.
@@ -54,34 +50,14 @@ abstract contract CoWProtocol is Test, Tokens {
         /// @dev the solver account simulates a solver in the allow list
         solver = TestAccountLib.createTestAccount("solver");
 
-        authorizer = new Authorizer(admin.addr);
-
-        // deploy the Balancer vault
-        // parameters taken from mainnet initialization:
-        //   Arg [0] : authorizer (address): 0xA331D84eC860Bf466b4CdCcFb4aC09a1B43F3aE6
-        //   Arg [1] : weth (address): 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
-        //   Arg [2] : pauseWindowDuration (uint256): 7776000
-        //   Arg [3] : bufferPeriodDuration (uint256): 2592000
-        vault = GPv2IVault(
-            address(
-                new Vault(
-                    authorizer,
-                    weth,
-                    PAUSE_WINDOW_DURATION,
-                    BUFFER_PERIOD_DURATION
-                )
-            )
-        );
+        vault = IVault(makeAddr("fakeVault"));
 
         // deploy the allow list manager
         GPv2AllowListAuthentication allowList = new GPv2AllowListAuthentication();
         allowList.initializeManager(admin.addr);
 
         /// @dev the settlement contract is the main entry point for the CoW Protocol
-        settlement = new GPv2Settlement(
-            allowList,
-            vault
-        );
+        settlement = new GPv2Settlement(allowList, vault);
 
         /// @dev the relayer is the account authorized to spend the user's tokens
         relayer = address(settlement.vaultRelayer());

--- a/test/helpers/Safe.t.sol
+++ b/test/helpers/Safe.t.sol
@@ -7,7 +7,7 @@ import {SafeProxyFactory} from "safe/proxies/SafeProxyFactory.sol";
 import {CompatibilityFallbackHandler} from "safe/handler/CompatibilityFallbackHandler.sol";
 import {MultiSend} from "safe/libraries/MultiSend.sol";
 import {SignMessageLib} from "safe/libraries/SignMessageLib.sol";
-import "safe/handler/ExtensibleFallbackHandler.sol";
+import {ExtensibleFallbackHandler, FallbackHandler, MarshalLib} from "safe/handler/ExtensibleFallbackHandler.sol";
 
 import {SafeLib} from "../libraries/SafeLib.t.sol";
 import {TestAccount, TestAccountLib} from "../libraries/TestAccountLib.t.sol";

--- a/test/helpers/Tokens.t.sol
+++ b/test/helpers/Tokens.t.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {IERC20, ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "cowprotocol/contracts/interfaces/IERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 /// @title Mock ERC20 token for testing.
 /// @author mfw78 <mfw78@rndlabs.xyz>

--- a/test/vendored/GPv2TradeEncoder.sol
+++ b/test/vendored/GPv2TradeEncoder.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {IERC20} from "@openzeppelin/interfaces/IERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
-import {GPv2Order} from "cowprotocol/libraries/GPv2Order.sol";
-import {GPv2Signing} from "cowprotocol/mixins/GPv2Signing.sol";
+import {GPv2Order} from "cowprotocol/contracts/libraries/GPv2Order.sol";
+import {GPv2Signing} from "cowprotocol/contracts/mixins/GPv2Signing.sol";
 
 /// @title Gnosis Protocol v2 Trade Library.
 /// @author mfw78 <mfw78@rndlabs.xyz>


### PR DESCRIPTION
# Description
Recently some upstream submodules were deleted which resulted in the head branch breaking.

Specifically, these were:

- https://github.com/rndlabs/cowswap-contracts
- https://github.com/rndlabs/balancer
- https://github.com/rndlabs/canonical-weth

These are mostly used in the course of testing. There have also been issues caused in other development associated with ComposableCoW (a.k.a programmatic orders framework) with the large amount of dependencies / git submodule treatment of such.

# Changes

- [x] Added a devcontainer for quality of life improvement
- [x] Removed aforementioned submodules
- [x] Added new `cowprotocol` module targeting `main` branch of upstream to take advantage of contracts already having had their `pragma` bumped :rocket: 
- [x] Refactored all contracts to make all imports explicit - eliminating annoying `IERC20` conflicts
- [x] Removed `safe` module referencing https://github.com/rndlabs and now targets https://github.com/cowdao-grants/extensible-fallback-handler

## How to test
1. CI/CD
2. Observe no logic changes in code - only specific import changes