### PR TITLE
Refactor stop-loss create just 1 discrete order

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "solidity.packageDefaultDependenciesContractsDirectory": "src",
-  "solidity.packageDefaultDependenciesDirectory": "lib"
+  "solidity.packageDefaultDependenciesDirectory": "lib",
+  "solidity.compileUsingRemoteVersion": "v0.8.26+commit.8a97fa7a"
 }

--- a/src/types/StopLoss.sol
+++ b/src/types/StopLoss.sol
@@ -13,6 +13,8 @@ string constant ORACLE_INVALID_PRICE = "oracle invalid price";
 string constant ORACLE_STALE_PRICE = "oracle stale price";
 /// @dev The strike price has not been reached
 string constant STRIKE_NOT_REACHED = "strike not reached";
+/// @dev The order is not valid anymore
+string constant ORDER_EXPIRED = "order expired";
 
 /**
  * @title StopLoss conditional order
@@ -34,7 +36,7 @@ contract StopLoss is BaseConditionalOrder {
      * @param receiver: The account that should receive the proceeds of the trade
      * @param isSellOrder: Whether this is a sell or buy order
      * @param isPartiallyFillable: Whether solvers are allowed to only fill a fraction of the order (useful if exact sell or buy amount isn't know at time of placement)
-     * @param validityBucketSeconds: How long the order will be valid. E.g. if the validityBucket is set to 15 minutes and the order is placed at 00:08, it will be valid until 00:15
+     * @param validTo: The UNIX timestamp that sets how long the order will be valid for
      * @param sellTokenPriceOracle: A chainlink-like oracle returning the current sell token price in a given numeraire
      * @param buyTokenPriceOracle: A chainlink-like oracle returning the current buy token price in the same numeraire
      * @param strike: The exchange rate (denominated in sellToken/buyToken) which triggers the StopLoss order if the oracle price falls below. Specified in base / quote with 18 decimals.
@@ -49,7 +51,7 @@ contract StopLoss is BaseConditionalOrder {
         address receiver;
         bool isSellOrder;
         bool isPartiallyFillable;
-        uint32 validityBucketSeconds;
+        uint32 validTo;
         IAggregatorV3Interface sellTokenPriceOracle;
         IAggregatorV3Interface buyTokenPriceOracle;
         int256 strike;
@@ -65,6 +67,11 @@ contract StopLoss is BaseConditionalOrder {
         Data memory data = abi.decode(staticInput, (Data));
         // scope variables to avoid stack too deep error
         {
+            /// @dev Guard against expired orders
+            if (data.validTo < block.timestamp) {
+                revert IConditionalOrder.OrderNotValid(ORDER_EXPIRED);
+            }
+
             (, int256 basePrice,, uint256 sellUpdatedAt,) = data.sellTokenPriceOracle.latestRoundData();
             (, int256 quotePrice,, uint256 buyUpdatedAt,) = data.buyTokenPriceOracle.latestRoundData();
 
@@ -100,7 +107,7 @@ contract StopLoss is BaseConditionalOrder {
             data.receiver,
             data.sellAmount,
             data.buyAmount,
-            Utils.validToBucket(data.validityBucketSeconds),
+            data.validTo,
             data.appData,
             0, // use zero fee for limit orders
             data.isSellOrder ? GPv2Order.KIND_SELL : GPv2Order.KIND_BUY,

--- a/src/types/StopLoss.sol
+++ b/src/types/StopLoss.sol
@@ -36,7 +36,7 @@ contract StopLoss is BaseConditionalOrder {
      * @param receiver: The account that should receive the proceeds of the trade
      * @param isSellOrder: Whether this is a sell or buy order
      * @param isPartiallyFillable: Whether solvers are allowed to only fill a fraction of the order (useful if exact sell or buy amount isn't know at time of placement)
-     * @param validTo: The UNIX timestamp that sets how long the order will be valid for
+     * @param validTo: The UNIX timestamp before which this order is valid
      * @param sellTokenPriceOracle: A chainlink-like oracle returning the current sell token price in a given numeraire
      * @param buyTokenPriceOracle: A chainlink-like oracle returning the current buy token price in the same numeraire
      * @param strike: The exchange rate (denominated in sellToken/buyToken) which triggers the StopLoss order if the oracle price falls below. Specified in base / quote with 18 decimals.

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -327,14 +327,20 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         );
     }
 
-    function test_strikePriceMet_fuzz(int256 sellTokenOraclePrice, int256 buyTokenOraclePrice, int256 strike) public {
+    function test_strikePriceMet_fuzz(
+        int256 sellTokenOraclePrice,
+        int256 buyTokenOraclePrice,
+        int256 strike,
+        uint32 validTo
+    ) public {
+        // 25 June 2023 18:40:51
+        vm.warp(1687718451);
+
+        vm.assume(validTo >= block.timestamp);
         vm.assume(buyTokenOraclePrice > 0);
         vm.assume(sellTokenOraclePrice > 0 && sellTokenOraclePrice <= type(int256).max / 10 ** 18);
         vm.assume(strike > 0);
         vm.assume(sellTokenOraclePrice * int256(10 ** 18) / buyTokenOraclePrice <= strike);
-
-        // 25 June 2023 18:40:51
-        vm.warp(1687718451);
 
         StopLoss.Data memory data = StopLoss.Data({
             sellToken: mockToken(SELL_TOKEN, DEFAULT_DECIMALS),
@@ -348,7 +354,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             receiver: address(0x0),
             isSellOrder: false,
             isPartiallyFillable: false,
-            validTo: type(uint32).max,
+            validTo: validTo,
             maxTimeSinceLastOracleUpdate: 15 minutes
         });
 
@@ -359,7 +365,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         assertEq(order.sellAmount, 1 ether);
         assertEq(order.buyAmount, 1 ether);
         assertEq(order.receiver, address(0x0));
-        assertEq(order.validTo, type(uint32).max);
+        assertEq(order.validTo, validTo);
         assertEq(order.appData, APP_DATA);
         assertEq(order.feeAmount, 0);
         assertEq(order.kind, GPv2Order.KIND_BUY);

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -287,7 +287,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
-    function test_OracleRevertOnExpiriedOrder_fuzz(
+    function test_OracleRevertOnExpiredOrder_fuzz(
         uint32 currentTime,
         uint32 validTo
     ) public {

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -287,7 +287,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
-    function test_OracleRevertOnExperiedOrder_fuzz(
+    function test_OracleRevertOnExpiriedOrder_fuzz(
         uint32 currentTime,
         uint32 validTo
     ) public {


### PR DESCRIPTION
# Description
- Avoid multiple discrete order creations for one stop-loss order creation.

# Changes
- [x] Replace the `validityBucketTime` parameter of stop loss data with constant `validTo`.

## How to test
1. Run the modified local test.
2. Try to create multiple discrete orders from the same stop-loss order using the deployed contract on sepolia: `0xe6CDbC068654C506424F7747357F51d0e7caB00e`