### PR TITLE
fix: fixed deployment handling and contract initialization updates

### DIFF
--- a/script/deploy_ProdStack.s.sol
+++ b/script/deploy_ProdStack.s.sol
@@ -32,8 +32,8 @@ contract DeployProdStack is Script {
         // Deploy ComposableCoW
         ComposableCoW composableCow = new ComposableCoW{salt: "v1.0.0"}(settlement);
 
-        // Deploy order types
-        new TWAP{salt: "v1.0.0"}(composableCow);
+        // Deploy order types (assuming these do not need the composableCow as a parameter)
+        new TWAP{salt: "v1.0.0"}(address(composableCow));  // If TWAP requires composableCow's address
         new GoodAfterTime{salt: "v1.0.0"}();
         new PerpetualStableSwap{salt: "v1.0.0"}();
         new TradeAboveThreshold{salt: "v1.0.0"}();
@@ -41,5 +41,7 @@ contract DeployProdStack is Script {
 
         // Deploy value factories
         new CurrentBlockTimestampFactory{salt: "v1.0.0"}();
+
+        vm.stopBroadcast();  // End the broadcast
     }
 }


### PR DESCRIPTION
# Description  
I added the call to `vm.stopBroadcast()` to properly finalize the deployment transaction. For the TWAP contract, I suggested passing the address of the deployed ComposableCoW contract to its constructor, assuming it's needed. Additionally, I reminded that if other contracts like GoodAfterTime or PerpetualStableSwap require extra parameters, they should be passed into their respective constructors as well.

# Changes  
- Added `vm.stopBroadcast()` to finalize deployment transaction.
- Suggested passing the ComposableCoW contract address to TWAP's constructor.
- Noted the need to pass additional parameters to other contracts (e.g., GoodAfterTime, PerpetualStableSwap).

## How to test  
1. Deploy the contract and ensure the transaction is finalized by `vm.stopBroadcast()`.
2. Verify that the TWAP contract receives the correct ComposableCoW address in its constructor.
3. Ensure other contracts (GoodAfterTime, PerpetualStableSwap) are receiving necessary constructor parameters if required.
