### PR TITLE
feat: base ComposableCowPoller contract

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,6 @@
 [profile.default]
 src = 'src'
+test = 'test'
 out = 'out'
 libs = ['lib']
 

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+/// @title ComposableCowPoller - Just-in-time funding for composable conditional orders.
+contract ComposableCowPoller {}

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -18,6 +18,6 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
     }
 
     function test_deployment() public {
-        assertTrue(address(poller) != address(0), "poller deployed");
+        assertTrue(address(poller).code.length > 0, "poller deployed");
     }
 }

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import {BaseComposableCoWTest} from "./ComposableCoW.base.t.sol";
+
+import {ComposableCowPoller} from "../src/types/ComposableCowPoller.sol";
+
+/// @title ComposableCowPoller unit tests
+/// @notice Base scaffolding for the poller. Feature-specific tests (register / revoke / topUp) are
+///         added in follow-up PRs.
+contract ComposableCowPollerTest is BaseComposableCoWTest {
+    ComposableCowPoller poller;
+
+    function setUp() public virtual override(BaseComposableCoWTest) {
+        super.setUp();
+
+        poller = new ComposableCowPoller();
+    }
+
+    function test_deployment() public {
+        assertTrue(address(poller) != address(0), "poller deployed");
+    }
+}

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {BaseComposableCoWTest} from "./ComposableCoW.base.t.sol";
+import {BaseComposableCoWTest} from "test/ComposableCoW.base.t.sol";
 
-import {ComposableCowPoller} from "../src/types/ComposableCowPoller.sol";
+import {ComposableCowPoller} from "src/types/ComposableCowPoller.sol";
 
 /// @title ComposableCowPoller unit tests
 /// @notice Base scaffolding for the poller. Feature-specific tests (register / revoke / topUp) are


### PR DESCRIPTION
Part of #121.

## What
Introduces the base `ComposableCowPoller` contract as an empty shell (no state, no functions yet) plus the empty `test/ComposableCowPoller.t.sol` scaffolding. 

This is the base for follow up PRs which will add features to the contract.

## Test plan
```bash
forge test --match-contract ComposableCowPollerTest -vv
```
Test should pass
