### PR TITLE
feat: register a polling schedule

### DIFF
--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -8,15 +8,23 @@ contract ComposableCowPoller {
     /// @notice Parameters for a JIT funding schedule.
     /// @dev A schedule is uniquely identified by its funder, handler, owner, and salt.
     struct Schedule {
-        IConditionalOrderGenerator handler; // the conditional-order handler to poll (e.g. the TWAP type)
-        address funder; // source of funds; the only registrant
-        address owner; // order owner; the pull destination
-        bytes32 salt; // the conditional order's salt
-        bytes staticInput; // the order's staticInput
+        /// @notice The conditional-order handler to poll, such as the TWAP type.
+        IConditionalOrderGenerator handler;
+        /// @notice The address allowed to register this schedule and later debited for sell tokens.
+        /// @dev It can be an EOA or contract and may be the same address as `owner`.
+        address funder;
+        /// @notice The address that owns the ComposableCoW conditional order and receives the pulled funds.
+        /// @dev It can be an EOA or contract and may be the same address as `funder`.
+        address owner;
+        /// @notice A user-controlled namespace for this schedule.
+        /// @dev Use a value unique to the user and order. Deriving it from order-defining static-input values,
+        ///      excluding appData, is recommended.
+        bytes32 salt;
+        /// @notice The static input passed to the handler when it generates an order.
+        bytes staticInput;
     }
 
-    /// @dev Keyed by `id == scheduleId(funder, handler, owner, salt)`, which is independent of the
-    ///      order's `appData`.
+    /// @dev Keyed by `id == scheduleId(schedule)`, which excludes the order's `appData`.
     mapping(bytes32 => Schedule) public schedules;
 
     /// @notice Thrown when someone other than the schedule funder registers or updates a schedule.
@@ -31,17 +39,10 @@ contract ComposableCowPoller {
     /// @notice Computes the deterministic, appData-independent schedule key.
     /// @dev `staticInput` is excluded because its appData can depend on this key.
     ///      Use a different salt for concurrent schedules with the same funder, handler, and owner.
-    /// @param funder The token source.
-    /// @param handler The conditional-order generator.
-    /// @param owner The conditional-order owner.
-    /// @param salt The conditional-order salt.
+    /// @param schedule The schedule whose identity fields determine the key.
     /// @return The schedule key.
-    function scheduleId(address funder, IConditionalOrderGenerator handler, address owner, bytes32 salt)
-        public
-        pure
-        returns (bytes32)
-    {
-        return keccak256(abi.encode(funder, handler, owner, salt));
+    function scheduleId(Schedule memory schedule) public pure returns (bytes32) {
+        return keccak256(abi.encode(schedule.funder, schedule.handler, schedule.owner, schedule.salt));
     }
 
     /// @notice Registers or updates a schedule.
@@ -51,7 +52,7 @@ contract ComposableCowPoller {
     /// @return id The deterministic key of the stored schedule.
     function register(Schedule calldata schedule) external returns (bytes32 id) {
         if (msg.sender != schedule.funder) revert OnlyFunder();
-        id = scheduleId(schedule.funder, schedule.handler, schedule.owner, schedule.salt);
+        id = scheduleId(schedule);
         schedules[id] = schedule;
         emit ScheduleRegistered(id, schedule.owner, schedule.funder);
     }

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -1,5 +1,41 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
+import {IConditionalOrderGenerator} from "../interfaces/IConditionalOrder.sol";
+
 /// @title ComposableCowPoller - Just-in-time funding for composable conditional orders.
-contract ComposableCowPoller {}
+contract ComposableCowPoller {
+    struct Schedule {
+        IConditionalOrderGenerator handler; // the conditional-order handler to poll (e.g. the TWAP type)
+        address funder; // source of funds; the only registrant
+        address owner; // order owner; the pull destination
+        bytes32 salt; // the conditional order's salt
+        bytes staticInput; // the order's staticInput
+    }
+
+    /// @dev Keyed by `id == scheduleId(funder, handler, owner, salt)`, which is independent of the
+    ///      order's `appData`.
+    mapping(bytes32 => Schedule) public schedules;
+
+    error OnlyFunder();
+
+    event ScheduleRegistered(bytes32 indexed id, address indexed owner, address indexed funder);
+
+    /// @notice Deterministic, appData-independent schedule key.
+    function scheduleId(address funder, IConditionalOrderGenerator handler, address owner, bytes32 salt)
+        public
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(funder, handler, owner, salt));
+    }
+
+    /// @notice Register or update a schedule. Only the funds source may register, and the `id` is
+    ///         namespaced by `funder`.
+    function register(Schedule calldata schedule) external returns (bytes32 id) {
+        if (msg.sender != schedule.funder) revert OnlyFunder();
+        id = scheduleId(schedule.funder, schedule.handler, schedule.owner, schedule.salt);
+        schedules[id] = schedule;
+        emit ScheduleRegistered(id, schedule.owner, schedule.funder);
+    }
+}

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {IConditionalOrderGenerator} from "../interfaces/IConditionalOrder.sol";
+import {IConditionalOrderGenerator} from "src/interfaces/IConditionalOrder.sol";
 
 /// @title ComposableCowPoller - Just-in-time funding for composable conditional orders.
 contract ComposableCowPoller {
+    /// @notice Parameters for a JIT funding schedule.
+    /// @dev A schedule is uniquely identified by its funder, handler, owner, and salt.
     struct Schedule {
         IConditionalOrderGenerator handler; // the conditional-order handler to poll (e.g. the TWAP type)
         address funder; // source of funds; the only registrant
@@ -17,11 +19,23 @@ contract ComposableCowPoller {
     ///      order's `appData`.
     mapping(bytes32 => Schedule) public schedules;
 
+    /// @notice Thrown when someone other than the schedule funder registers or updates a schedule.
     error OnlyFunder();
 
+    /// @notice Emitted when a schedule is registered or updated.
+    /// @param id The deterministic key of the schedule.
+    /// @param owner The conditional-order owner and pull destination.
+    /// @param funder The token source that registered the schedule.
     event ScheduleRegistered(bytes32 indexed id, address indexed owner, address indexed funder);
 
-    /// @notice Deterministic, appData-independent schedule key.
+    /// @notice Computes the deterministic, appData-independent schedule key.
+    /// @dev `staticInput` is excluded because its appData can depend on this key.
+    ///      Use a different salt for concurrent schedules with the same funder, handler, and owner.
+    /// @param funder The token source.
+    /// @param handler The conditional-order generator.
+    /// @param owner The conditional-order owner.
+    /// @param salt The conditional-order salt.
+    /// @return The schedule key.
     function scheduleId(address funder, IConditionalOrderGenerator handler, address owner, bytes32 salt)
         public
         pure
@@ -30,8 +44,11 @@ contract ComposableCowPoller {
         return keccak256(abi.encode(funder, handler, owner, salt));
     }
 
-    /// @notice Register or update a schedule. Only the funds source may register, and the `id` is
-    ///         namespaced by `funder`.
+    /// @notice Registers or updates a schedule.
+    /// @dev Registering the same funder, handler, owner, and salt replaces the stored schedule.
+    ///      Only the funds source may register, and the ID is namespaced by the funder.
+    /// @param schedule The schedule to store.
+    /// @return id The deterministic key of the stored schedule.
     function register(Schedule calldata schedule) external returns (bytes32 id) {
         if (msg.sender != schedule.funder) revert OnlyFunder();
         id = scheduleId(schedule.funder, schedule.handler, schedule.owner, schedule.salt);

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -51,7 +51,7 @@ contract ComposableCowPoller {
     /// @param schedule The schedule to store.
     /// @return id The deterministic key of the stored schedule.
     function register(Schedule calldata schedule) external returns (bytes32 id) {
-        if (msg.sender != schedule.funder) revert OnlyFunder();
+    require(msg.sender == schedule.funder, OnlyFunder());
         id = scheduleId(schedule);
         schedules[id] = schedule;
         emit ScheduleRegistered(id, schedule.owner, schedule.funder);

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -51,7 +51,7 @@ contract ComposableCowPoller {
     /// @param schedule The schedule to store.
     /// @return id The deterministic key of the stored schedule.
     function register(Schedule calldata schedule) external returns (bytes32 id) {
-    require(msg.sender == schedule.funder, OnlyFunder());
+        if (msg.sender != schedule.funder) revert OnlyFunder();
         id = scheduleId(schedule);
         schedules[id] = schedule;
         emit ScheduleRegistered(id, schedule.owner, schedule.funder);

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -1,23 +1,137 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {BaseComposableCoWTest} from "test/ComposableCoW.base.t.sol";
+import {IConditionalOrder, IValueFactory, BaseComposableCoWTest} from "test/ComposableCoW.base.t.sol";
 
+import {TWAP} from "src/types/twap/TWAP.sol";
+import {TWAPOrder} from "src/types/twap/libraries/TWAPOrder.sol";
 import {ComposableCowPoller} from "src/types/ComposableCowPoller.sol";
+import {CurrentBlockTimestampFactory} from "src/value_factories/CurrentBlockTimestampFactory.sol";
+import {IConditionalOrderGenerator} from "src/interfaces/IConditionalOrder.sol";
 
 /// @title ComposableCowPoller unit tests
-/// @notice Base scaffolding for the poller. Feature-specific tests (register / revoke / topUp) are
-///         added in follow-up PRs.
+/// @notice Exercises registering a schedule for a composable TWAP created via `createWithContext`.
 contract ComposableCowPollerTest is BaseComposableCoWTest {
+    uint256 constant PART = 100e18;
+    uint256 constant LIMIT = 1e18;
+    uint256 constant N = 3;
+    uint256 constant FREQ = 1 hours;
+    bytes32 constant SALT = keccak256("twap");
+
     ComposableCowPoller poller;
+    IValueFactory currentBlockTimestampFactory;
+
+    address funder;
 
     function setUp() public virtual override(BaseComposableCoWTest) {
         super.setUp();
 
+        twap = new TWAP(composableCow);
+        currentBlockTimestampFactory = new CurrentBlockTimestampFactory();
         poller = new ComposableCowPoller();
+        funder = makeAddr("funder");
+
+        // The owner (safe1) starts with no sell token: funds arrive just-in-time.
+        deal(address(token0), address(safe1), 0);
     }
 
     function test_deployment() public {
         assertTrue(address(poller).code.length > 0, "poller deployed");
+    }
+
+    function _bundle() internal view returns (TWAPOrder.Data memory) {
+        return
+            TWAPOrder.Data({
+                sellToken: token0,
+                buyToken: token1,
+                receiver: address(0), // the owner itself
+                partSellAmount: PART,
+                minPartLimit: LIMIT,
+                t0: 0, // resolved from the cabinet via createWithContext
+                n: N,
+                t: FREQ,
+                span: 0, // valid for the whole epoch
+                appData: keccak256("dca.pull")
+            });
+    }
+
+    /// @dev Creates a JIT-funded TWAP: order via context, the funder funds + approves the poller,
+    ///      and the schedule is registered. Returns the order's cabinet key `ctx`
+    ///      (`ComposableCoW.hash(params)`, used for cabinet/remove) and the appData-independent
+    ///      poller schedule key `id` (used for topUp/revoke).
+    function _setupSchedule()
+        internal
+        returns (
+            IConditionalOrder.ConditionalOrderParams memory params,
+            bytes32 ctx,
+            bytes32 id
+        )
+    {
+        params = super.createOrder(twap, SALT, abi.encode(_bundle()));
+        _createWithContext(
+            address(safe1),
+            params,
+            currentBlockTimestampFactory,
+            bytes(""),
+            false
+        );
+        ctx = composableCow.hash(params);
+
+        // Capital lives in the funder (the EOA), which approves the poller for the full notional.
+        deal(address(token0), funder, PART * N);
+        vm.prank(funder);
+        token0.approve(address(poller), PART * N);
+
+        // Register the schedule (only the funder may do this). The schedule carries the handler,
+        // the funds source, the destination, the order's `salt` (so the poller can rebuild `ctx`
+        // on-chain) and its `staticInput`. The key is appData-independent so the funding hook can
+        // live in the order's own appData.
+        vm.prank(funder);
+        id = poller.register(
+            ComposableCowPoller.Schedule({
+                handler: IConditionalOrderGenerator(address(twap)),
+                funder: funder,
+                owner: address(safe1),
+                salt: SALT,
+                staticInput: abi.encode(_bundle())
+            })
+        );
+
+        assertEq(
+            id,
+            poller.scheduleId(
+                funder,
+                IConditionalOrderGenerator(address(twap)),
+                address(safe1),
+                SALT
+            ),
+            "id matches the off-chain derivation"
+        );
+    }
+
+    /// @dev A registered schedule is stored under its appData-independent id.
+    function test_register_storesSchedule() public {
+        (, , bytes32 id) = _setupSchedule();
+
+        (IConditionalOrderGenerator handler, address scheduleFunder, address owner, bytes32 salt,) =
+            poller.schedules(id);
+        assertEq(address(handler), address(twap), "handler stored");
+        assertEq(scheduleFunder, funder, "funder stored");
+        assertEq(owner, address(safe1), "owner stored");
+        assertEq(salt, SALT, "salt stored");
+    }
+
+    /// @dev Only the funds source may register a schedule that draws on its own funds.
+    function test_register_RevertWhen_notFunder() public {
+        vm.expectRevert(ComposableCowPoller.OnlyFunder.selector);
+        poller.register(
+            ComposableCowPoller.Schedule({
+                handler: IConditionalOrderGenerator(address(twap)),
+                funder: funder, // attacker points at someone else's funds
+                owner: address(safe1),
+                salt: SALT,
+                staticInput: abi.encode(_bundle())
+            })
+        );
     }
 }

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -12,7 +12,7 @@ import {IConditionalOrderGenerator} from "src/interfaces/IConditionalOrder.sol";
 /// @title ComposableCowPoller unit tests
 /// @notice Exercises registering a schedule for a composable TWAP created via `createWithContext`.
 contract ComposableCowPollerTest is BaseComposableCoWTest {
-    uint256 constant PART = 100e18;
+    uint256 constant TWAP_PART_AMOUNT = 100e18;
     uint256 constant LIMIT = 1e18;
     uint256 constant N = 3;
     uint256 constant FREQ = 1 hours;
@@ -45,7 +45,7 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
             sellToken: token0,
             buyToken: token1,
             receiver: address(0), // protocol shorthand for the Safe owner
-            partSellAmount: PART,
+            partSellAmount: TWAP_PART_AMOUNT,
             minPartLimit: LIMIT,
             t0: 0, // resolved from the cabinet via createWithContext
             n: N,
@@ -68,34 +68,37 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         ctx = composableCow.hash(params);
 
         // Capital lives in the funder (the EOA), which approves the poller for the full notional.
-        deal(address(token0), funder, PART * N);
+        deal(address(token0), funder, TWAP_PART_AMOUNT * N);
         vm.prank(funder);
-        token0.approve(address(poller), PART * N);
+        token0.approve(address(poller), TWAP_PART_AMOUNT * N);
 
         // Register the schedule (only the funder may do this). The schedule carries the handler,
         // the funds source, the destination, the order's `salt` (so the poller can rebuild `ctx`
         // on-chain) and its `staticInput`. The key is appData-independent so the funding hook can
         // live in the order's own appData.
-        id = _register(SALT, abi.encode(_bundle()));
+        ComposableCowPoller.Schedule memory schedule = _schedule(SALT, abi.encode(_bundle()));
+        id = _register(schedule);
 
-        assertEq(
-            id,
-            poller.scheduleId(funder, IConditionalOrderGenerator(address(twap)), address(safe1), SALT),
-            "id matches the off-chain derivation"
-        );
+        assertEq(id, poller.scheduleId(schedule), "id matches the off-chain derivation");
     }
 
-    function _register(bytes32 salt, bytes memory staticInput) internal returns (bytes32 id) {
+    function _schedule(bytes32 salt, bytes memory staticInput)
+        internal
+        view
+        returns (ComposableCowPoller.Schedule memory)
+    {
+        return ComposableCowPoller.Schedule({
+            handler: IConditionalOrderGenerator(address(twap)),
+            funder: funder,
+            owner: address(safe1),
+            salt: salt,
+            staticInput: staticInput
+        });
+    }
+
+    function _register(ComposableCowPoller.Schedule memory schedule) internal returns (bytes32 id) {
         vm.prank(funder);
-        id = poller.register(
-            ComposableCowPoller.Schedule({
-                handler: IConditionalOrderGenerator(address(twap)),
-                funder: funder,
-                owner: address(safe1),
-                salt: salt,
-                staticInput: staticInput
-            })
-        );
+        id = poller.register(schedule);
     }
 
     /// @dev A registered schedule is stored under its appData-independent id.
@@ -119,8 +122,8 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
     /// @dev Distinct salts allow concurrent schedules with the same funder, handler, and owner.
     function test_register_storesSchedulesWithDifferentSalts() public {
         bytes memory staticInput = abi.encode(_bundle());
-        bytes32 firstId = _register(SALT, staticInput);
-        bytes32 secondId = _register(SECOND_SALT, staticInput);
+        bytes32 firstId = _register(_schedule(SALT, staticInput));
+        bytes32 secondId = _register(_schedule(SECOND_SALT, staticInput));
 
         assertTrue(firstId != secondId, "different salts create different ids");
 
@@ -132,12 +135,12 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
 
     /// @dev Registering the same key updates the one schedule stored under that id.
     function test_register_replacesScheduleWithSameId() public {
-        bytes32 id = _register(SALT, abi.encode(_bundle()));
+        bytes32 id = _register(_schedule(SALT, abi.encode(_bundle())));
         TWAPOrder.Data memory replacement = _bundle();
         replacement.appData = keccak256("updated dca pull");
         bytes memory updatedStaticInput = abi.encode(replacement);
 
-        assertEq(_register(SALT, updatedStaticInput), id, "same key keeps same id");
+        assertEq(_register(_schedule(SALT, updatedStaticInput)), id, "same key keeps same id");
 
         (,,,, bytes memory staticInput) = poller.schedules(id);
         assertEq(staticInput, updatedStaticInput, "replacement input stored");

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -17,6 +17,7 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
     uint256 constant N = 3;
     uint256 constant FREQ = 1 hours;
     bytes32 constant SALT = keccak256("twap");
+    bytes32 constant SECOND_SALT = keccak256("second twap");
 
     ComposableCowPoller poller;
     IValueFactory currentBlockTimestampFactory;
@@ -40,19 +41,18 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
     }
 
     function _bundle() internal view returns (TWAPOrder.Data memory) {
-        return
-            TWAPOrder.Data({
-                sellToken: token0,
-                buyToken: token1,
-                receiver: address(0), // the owner itself
-                partSellAmount: PART,
-                minPartLimit: LIMIT,
-                t0: 0, // resolved from the cabinet via createWithContext
-                n: N,
-                t: FREQ,
-                span: 0, // valid for the whole epoch
-                appData: keccak256("dca.pull")
-            });
+        return TWAPOrder.Data({
+            sellToken: token0,
+            buyToken: token1,
+            receiver: address(0), // protocol shorthand for the Safe owner
+            partSellAmount: PART,
+            minPartLimit: LIMIT,
+            t0: 0, // resolved from the cabinet via createWithContext
+            n: N,
+            t: FREQ,
+            span: 0, // each part is valid for its full FREQ interval
+            appData: keccak256("dca.pull")
+        });
     }
 
     /// @dev Creates a JIT-funded TWAP: order via context, the funder funds + approves the poller,
@@ -61,20 +61,10 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
     ///      poller schedule key `id` (used for topUp/revoke).
     function _setupSchedule()
         internal
-        returns (
-            IConditionalOrder.ConditionalOrderParams memory params,
-            bytes32 ctx,
-            bytes32 id
-        )
+        returns (IConditionalOrder.ConditionalOrderParams memory params, bytes32 ctx, bytes32 id)
     {
         params = super.createOrder(twap, SALT, abi.encode(_bundle()));
-        _createWithContext(
-            address(safe1),
-            params,
-            currentBlockTimestampFactory,
-            bytes(""),
-            false
-        );
+        _createWithContext(address(safe1), params, currentBlockTimestampFactory, bytes(""), false);
         ctx = composableCow.hash(params);
 
         // Capital lives in the funder (the EOA), which approves the poller for the full notional.
@@ -86,39 +76,71 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         // the funds source, the destination, the order's `salt` (so the poller can rebuild `ctx`
         // on-chain) and its `staticInput`. The key is appData-independent so the funding hook can
         // live in the order's own appData.
+        id = _register(SALT, abi.encode(_bundle()));
+
+        assertEq(
+            id,
+            poller.scheduleId(funder, IConditionalOrderGenerator(address(twap)), address(safe1), SALT),
+            "id matches the off-chain derivation"
+        );
+    }
+
+    function _register(bytes32 salt, bytes memory staticInput) internal returns (bytes32 id) {
         vm.prank(funder);
         id = poller.register(
             ComposableCowPoller.Schedule({
                 handler: IConditionalOrderGenerator(address(twap)),
                 funder: funder,
                 owner: address(safe1),
-                salt: SALT,
-                staticInput: abi.encode(_bundle())
+                salt: salt,
+                staticInput: staticInput
             })
-        );
-
-        assertEq(
-            id,
-            poller.scheduleId(
-                funder,
-                IConditionalOrderGenerator(address(twap)),
-                address(safe1),
-                SALT
-            ),
-            "id matches the off-chain derivation"
         );
     }
 
     /// @dev A registered schedule is stored under its appData-independent id.
     function test_register_storesSchedule() public {
-        (, , bytes32 id) = _setupSchedule();
+        (,, bytes32 id) = _setupSchedule();
 
-        (IConditionalOrderGenerator handler, address scheduleFunder, address owner, bytes32 salt,) =
-            poller.schedules(id);
+        (
+            IConditionalOrderGenerator handler,
+            address scheduleFunder,
+            address owner,
+            bytes32 salt,
+            bytes memory staticInput
+        ) = poller.schedules(id);
         assertEq(address(handler), address(twap), "handler stored");
         assertEq(scheduleFunder, funder, "funder stored");
         assertEq(owner, address(safe1), "owner stored");
         assertEq(salt, SALT, "salt stored");
+        assertEq(staticInput, abi.encode(_bundle()), "static input stored");
+    }
+
+    /// @dev Distinct salts allow concurrent schedules with the same funder, handler, and owner.
+    function test_register_storesSchedulesWithDifferentSalts() public {
+        bytes memory staticInput = abi.encode(_bundle());
+        bytes32 firstId = _register(SALT, staticInput);
+        bytes32 secondId = _register(SECOND_SALT, staticInput);
+
+        assertTrue(firstId != secondId, "different salts create different ids");
+
+        (,,, bytes32 firstSalt,) = poller.schedules(firstId);
+        (,,, bytes32 secondSalt,) = poller.schedules(secondId);
+        assertEq(firstSalt, SALT, "first schedule remains stored");
+        assertEq(secondSalt, SECOND_SALT, "second schedule stored");
+    }
+
+    /// @dev Registering the same key updates the one schedule stored under that id.
+    function test_register_replacesScheduleWithSameId() public {
+        bytes32 id = _register(SALT, abi.encode(_bundle()));
+        TWAPOrder.Data memory replacement = _bundle();
+        replacement.appData = keccak256("updated dca pull");
+        bytes memory updatedStaticInput = abi.encode(replacement);
+
+        assertEq(_register(SALT, updatedStaticInput), id, "same key keeps same id");
+
+        (,,,, bytes memory staticInput) = poller.schedules(id);
+        assertEq(staticInput, updatedStaticInput, "replacement input stored");
     }
 
     /// @dev Only the funds source may register a schedule that draws on its own funds.


### PR DESCRIPTION
Part of #121. Follow uo #116

The polling requires a pre-authorization from the funding account (the registration).

This pre-authorization is done by registering a **polling schedule**

## What
Adds the struct of the register.

The registrations are done using a `scheduleId` (`bytes32`). The PR provides a `pure` function that generates this id deterministically based on the funder, handler, owner and salt.

This pre-register is what will allow in a follow up PR to implement the constraints in the function that does the actual poll.

## Test plan
```bash
forge test --match-contract ComposableCowPollerTest -vv
```
Test pass
