### PR TITLE
feat: revoke a polling schedule

### DIFF
--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -35,6 +35,7 @@ contract ComposableCowPoller {
     /// @param owner The conditional-order owner and pull destination.
     /// @param funder The token source that registered the schedule.
     event ScheduleRegistered(bytes32 indexed id, address indexed owner, address indexed funder);
+    event ScheduleRevoked(bytes32 indexed id);
 
     /// @notice Computes the deterministic, appData-independent schedule key.
     /// @dev `staticInput` is excluded because its appData can depend on this key.
@@ -55,5 +56,13 @@ contract ComposableCowPoller {
         id = scheduleId(schedule);
         schedules[id] = schedule;
         emit ScheduleRegistered(id, schedule.owner, schedule.funder);
+    }
+
+    /// @notice Revoke a schedule. Only the funds source may do so. A standing ERC-20 allowance
+    ///         should be revoked separately to fully close the surface.
+    function revoke(bytes32 id) external {
+        if (msg.sender != schedules[id].funder) revert OnlyFunder();
+        delete schedules[id];
+        emit ScheduleRevoked(id);
     }
 }

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -35,7 +35,12 @@ contract ComposableCowPoller {
     /// @param owner The conditional-order owner and pull destination.
     /// @param funder The token source that registered the schedule.
     event ScheduleRegistered(bytes32 indexed id, address indexed owner, address indexed funder);
-    event ScheduleRevoked(bytes32 indexed id);
+
+    /// @notice Emitted when a schedule is revoked.
+    /// @param id The deterministic key of the revoked schedule.
+    /// @param owner The conditional-order owner that was the pull destination.
+    /// @param funder The token source that revoked the schedule.
+    event ScheduleRevoked(bytes32 indexed id, address indexed owner, address indexed funder);
 
     /// @notice Computes the deterministic, appData-independent schedule key.
     /// @dev `staticInput` is excluded because its appData can depend on this key.
@@ -61,8 +66,9 @@ contract ComposableCowPoller {
     /// @notice Revoke a schedule. Only the funds source may do so. A standing ERC-20 allowance
     ///         should be revoked separately to fully close the surface.
     function revoke(bytes32 id) external {
-        if (msg.sender != schedules[id].funder) revert OnlyFunder();
+        Schedule storage schedule = schedules[id];
+        if (msg.sender != schedule.funder) revert OnlyFunder();
+        emit ScheduleRevoked(id, schedule.owner, schedule.funder);
         delete schedules[id];
-        emit ScheduleRevoked(id);
     }
 }

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -67,7 +67,7 @@ contract ComposableCowPoller {
     ///         should be revoked separately to fully close the surface.
     function revoke(bytes32 id) external {
         Schedule storage schedule = schedules[id];
-    require(msg.sender == schedule.funder, OnlyFunder());
+        if (msg.sender != schedule.funder) revert OnlyFunder();
         emit ScheduleRevoked(id, schedule.owner, schedule.funder);
         delete schedules[id];
     }

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -67,7 +67,7 @@ contract ComposableCowPoller {
     ///         should be revoked separately to fully close the surface.
     function revoke(bytes32 id) external {
         Schedule storage schedule = schedules[id];
-        if (msg.sender != schedule.funder) revert OnlyFunder();
+    require(msg.sender == schedule.funder, OnlyFunder());
         emit ScheduleRevoked(id, schedule.owner, schedule.funder);
         delete schedules[id];
     }

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -159,4 +159,24 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
             })
         );
     }
+
+    /// @dev The funder can revoke, which clears the schedule.
+    function test_revoke_clearsSchedule() public {
+        (, , bytes32 id) = _setupSchedule();
+
+        vm.prank(funder);
+        poller.revoke(id);
+
+        // The schedule is cleared: its funder is zeroed.
+        (, address scheduleFunder, , ,) = poller.schedules(id);
+        assertEq(scheduleFunder, address(0), "schedule cleared");
+    }
+
+    /// @dev Only the funds source may revoke.
+    function test_revoke_RevertWhen_notFunder() public {
+        (, , bytes32 id) = _setupSchedule();
+
+        vm.expectRevert(ComposableCowPoller.OnlyFunder.selector);
+        poller.revoke(id);
+    }
 }

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -164,7 +164,7 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
 
     /// @dev The funder can revoke, which clears the schedule.
     function test_revoke_clearsSchedule() public {
-        (, , bytes32 id) = _setupSchedule();
+        (,, bytes32 id) = _setupSchedule();
 
         vm.expectEmit(true, true, true, true, address(poller));
         emit ScheduleRevoked(id, address(safe1), funder);
@@ -172,14 +172,24 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         vm.prank(funder);
         poller.revoke(id);
 
-        // The schedule is cleared: its funder is zeroed.
-        (, address scheduleFunder, , ,) = poller.schedules(id);
+        // The whole schedule is cleared.
+        (
+            IConditionalOrderGenerator handler,
+            address scheduleFunder,
+            address owner,
+            bytes32 salt,
+            bytes memory staticInput
+        ) = poller.schedules(id);
+        assertEq(address(handler), address(0), "handler cleared");
         assertEq(scheduleFunder, address(0), "schedule cleared");
+        assertEq(owner, address(0), "owner cleared");
+        assertEq(salt, bytes32(0), "salt cleared");
+        assertEq(staticInput, bytes(""), "static input cleared");
     }
 
     /// @dev Only the funds source may revoke.
     function test_revoke_RevertWhen_notFunder() public {
-        (, , bytes32 id) = _setupSchedule();
+        (,, bytes32 id) = _setupSchedule();
 
         vm.expectRevert(ComposableCowPoller.OnlyFunder.selector);
         poller.revoke(id);

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -24,6 +24,8 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
 
     address funder;
 
+    event ScheduleRevoked(bytes32 indexed id, address indexed owner, address indexed funder);
+
     function setUp() public virtual override(BaseComposableCoWTest) {
         super.setUp();
 
@@ -163,6 +165,9 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
     /// @dev The funder can revoke, which clears the schedule.
     function test_revoke_clearsSchedule() public {
         (, , bytes32 id) = _setupSchedule();
+
+        vm.expectEmit(true, true, true, true, address(poller));
+        emit ScheduleRevoked(id, address(safe1), funder);
 
         vm.prank(funder);
         poller.revoke(id);


### PR DESCRIPTION
Part of #121. Follows up https://github.com/cowprotocol/composable-cow/pull/123

## What
Adds `revoke(bytes32 id)` — only the schedule's `funder` may revoke, which clears the stored schedule and emits `ScheduleRevoked`.

## Why
Lets a funder tear down a schedule they registered. (A standing ERC-20 allowance should be revoked separately.)

## Test plan
```bash
forge test --match-contract ComposableCowPollerTest -vv
```
Covers `test_revoke_clearsSchedule` (funder-only guard + schedule cleared).
