### PR TITLE
feat: pollFunds for just-in-time order funding

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ To create a TWAP order:
 
 1. ABI-Encode the `IConditionalOrder.ConditionalOrderParams` struct with:
    - `handler`: set to the `TWAP` smart contract deployment.
-   - `salt`: set to a unique value.
+   - `salt`: use a value unique to the user and logical order. For poller schedules, a good default is
+     the hash of the order-defining `staticInput` values with any `appData` field set to zero.
    - `staticInput`: the ABI-encoded `TWAP.Data` struct.
 2. Use the `struct` from (1) as either a Merkle leaf, or with `ComposableCoW.create` to create a single conditional order.
 3. Approve `GPv2VaultRelayer` to trade `n x partSellAmount` of the safe's `sellToken` tokens (in the example above, `GPv2VaultRelayer` would receive approval for spending 12,000,000 DAI tokens).

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {IConditionalOrderGenerator} from "src/interfaces/IConditionalOrder.sol";
+import {IERC20, GPv2Order} from "cowprotocol/contracts/libraries/GPv2Order.sol";
+
+import {ComposableCoW} from "src/ComposableCoW.sol";
+import {IConditionalOrder, IConditionalOrderGenerator} from "src/interfaces/IConditionalOrder.sol";
 
 /// @title ComposableCowPoller - Just-in-time funding for composable conditional orders.
 contract ComposableCowPoller {
+    ComposableCoW public immutable composableCow;
+
     /// @notice Parameters for a JIT funding schedule.
     /// @dev A schedule is uniquely identified by its funder, handler, owner, and salt.
     struct Schedule {
@@ -27,14 +32,24 @@ contract ComposableCowPoller {
     /// @dev Keyed by `id == scheduleId(schedule)`, which excludes the order's `appData`.
     mapping(bytes32 => Schedule) public schedules;
 
+    /// @dev `id => digest` of the order last funded, so each order is funded at most once.
+    mapping(bytes32 => bytes32) public lastFunded;
+
     /// @notice Thrown when someone other than the schedule funder registers or updates a schedule.
     error OnlyFunder();
+    error NoSchedule();
+    error OrderNotLive();
 
     /// @notice Emitted when a schedule is registered or updated.
     /// @param id The deterministic key of the schedule.
     /// @param owner The conditional-order owner and pull destination.
     /// @param funder The token source that registered the schedule.
     event ScheduleRegistered(bytes32 indexed id, address indexed owner, address indexed funder);
+    event Pulled(bytes32 indexed id, bytes32 orderDigest, uint256 amount);
+
+    constructor(ComposableCoW _composableCow) {
+        composableCow = _composableCow;
+    }
 
     /// @notice Emitted when a schedule is revoked.
     /// @param id The deterministic key of the revoked schedule.
@@ -60,6 +75,7 @@ contract ComposableCowPoller {
         if (msg.sender != schedule.funder) revert OnlyFunder();
         id = scheduleId(schedule);
         schedules[id] = schedule;
+        delete lastFunded[id]; // reset funding history
         emit ScheduleRegistered(id, schedule.owner, schedule.funder);
     }
 
@@ -70,5 +86,37 @@ contract ComposableCowPoller {
         if (msg.sender != schedule.funder) revert OnlyFunder();
         emit ScheduleRevoked(id, schedule.owner, schedule.funder);
         delete schedules[id];
+    }
+
+    /// @notice Move the current order's `sellAmount` from the funder to the owner. Permissionless.
+    ///         The full amount always moves (no balance check), so one owner can serve several
+    ///         concurrent orders.
+    function pollFunds(bytes32 id) external {
+        Schedule memory schedule = schedules[id];
+        if (schedule.funder == address(0)) revert NoSchedule();
+
+        // Re-derive `ctx` on-chain, so `pollFunds(id)` stays independent of the order's `appData`.
+        bytes32 ctx = composableCow.hash(
+            IConditionalOrder.ConditionalOrderParams({
+                handler: schedule.handler,
+                salt: schedule.salt,
+                staticInput: schedule.staticInput
+            })
+        );
+
+        // The order must still be authorised; `remove` disables the poller.
+        if (!composableCow.singleOrders(schedule.owner, ctx)) revert OrderNotLive();
+
+        // The handler yields the current order and reverts outside its window.
+        GPv2Order.Data memory order =
+            schedule.handler.getTradeableOrder(schedule.owner, address(this), ctx, schedule.staticInput, bytes(""));
+
+        // Fund each order at most once.
+        bytes32 digest = GPv2Order.hash(order, composableCow.domainSeparator());
+        if (digest == lastFunded[id]) return;
+        lastFunded[id] = digest;
+
+        order.sellToken.transferFrom(schedule.funder, schedule.owner, order.sellAmount);
+        emit Pulled(id, digest, order.sellAmount);
     }
 }

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -11,7 +11,8 @@ import {IConditionalOrder, IConditionalOrderGenerator} from "src/interfaces/ICon
 contract ComposableCowPoller {
     using GPv2SafeERC20 for IERC20;
 
-    ComposableCoW public immutable composableCow;
+    /// @dev `ComposableCoW` stores the settlement domain separator supplied at deployment.
+    ComposableCoW public immutable COMPOSABLE_COW;
 
     /// @notice Parameters for a JIT funding schedule.
     /// @dev A schedule is uniquely identified by its funder, handler, owner, and salt.
@@ -25,8 +26,8 @@ contract ComposableCowPoller {
         /// @dev It can be an EOA or contract and may be the same address as `funder`.
         address owner;
         /// @notice A user-controlled namespace for this schedule.
-        /// @dev Use a value unique to the user and order. Deriving it from order-defining static-input values,
-        ///      excluding appData, is recommended.
+        /// @dev Keep it unique to the user and logical order. A good default is the hash of the
+        ///      order-defining static-input values with any appData field set to zero.
         bytes32 salt;
         /// @notice The static input passed to the handler when it generates an order.
         bytes staticInput;
@@ -35,8 +36,8 @@ contract ComposableCowPoller {
     /// @dev Keyed by `id == scheduleId(schedule)`, which excludes the order's `appData`.
     mapping(bytes32 => Schedule) public schedules;
 
-    /// @dev `id => digest` of the order last funded, so each order is funded at most once.
-    mapping(bytes32 => bytes32) public lastFunded;
+    /// @dev `id => digest => funded`. History survives schedule updates so an old order cannot be replayed.
+    mapping(bytes32 => mapping(bytes32 => bool)) public funded;
 
     /// @notice Thrown when someone other than the schedule funder registers or updates a schedule.
     error OnlyFunder();
@@ -51,7 +52,7 @@ contract ComposableCowPoller {
     event Pulled(bytes32 indexed id, bytes32 orderDigest, uint256 amount);
 
     constructor(ComposableCoW _composableCow) {
-        composableCow = _composableCow;
+        COMPOSABLE_COW = _composableCow;
     }
 
     /// @notice Emitted when a schedule is revoked.
@@ -62,7 +63,8 @@ contract ComposableCowPoller {
 
     /// @notice Computes the deterministic, appData-independent schedule key.
     /// @dev `staticInput` is excluded because its appData can depend on this key.
-    ///      Use a different salt for concurrent schedules with the same funder, handler, and owner.
+    ///      Keep the salt unique to the user and logical order. A good default is the hash of the
+    ///      order-defining static-input values with any appData field set to zero.
     /// @param schedule The schedule whose identity fields determine the key.
     /// @return The schedule key.
     function scheduleId(Schedule memory schedule) public pure returns (bytes32) {
@@ -71,14 +73,14 @@ contract ComposableCowPoller {
 
     /// @notice Registers or updates a schedule.
     /// @dev Registering the same funder, handler, owner, and salt replaces the stored schedule.
-    ///      Only the funds source may register, and the ID is namespaced by the funder.
+    ///      Only the funds source may register, and the ID is namespaced by the funder. Funding
+    ///      history is preserved across updates; use a new salt for a new logical schedule.
     /// @param schedule The schedule to store.
     /// @return id The deterministic key of the stored schedule.
     function register(Schedule calldata schedule) external returns (bytes32 id) {
         if (msg.sender != schedule.funder) revert OnlyFunder();
         id = scheduleId(schedule);
         schedules[id] = schedule;
-        delete lastFunded[id]; // reset funding history
         emit ScheduleRegistered(id, schedule.owner, schedule.funder);
     }
 
@@ -99,25 +101,23 @@ contract ComposableCowPoller {
         if (schedule.funder == address(0)) revert NoSchedule();
 
         // Re-derive `ctx` on-chain, so `pollFunds(id)` stays independent of the order's `appData`.
-        bytes32 ctx = composableCow.hash(
+        bytes32 ctx = COMPOSABLE_COW.hash(
             IConditionalOrder.ConditionalOrderParams({
-                handler: schedule.handler,
-                salt: schedule.salt,
-                staticInput: schedule.staticInput
+                handler: schedule.handler, salt: schedule.salt, staticInput: schedule.staticInput
             })
         );
 
         // The order must still be authorised; `remove` disables the poller.
-        if (!composableCow.singleOrders(schedule.owner, ctx)) revert OrderNotLive();
+        if (!COMPOSABLE_COW.singleOrders(schedule.owner, ctx)) revert OrderNotLive();
 
         // The handler yields the current order and reverts outside its window.
         GPv2Order.Data memory order =
             schedule.handler.getTradeableOrder(schedule.owner, address(this), ctx, schedule.staticInput, bytes(""));
 
-        // Fund each order at most once.
-        bytes32 digest = GPv2Order.hash(order, composableCow.domainSeparator());
-        if (digest == lastFunded[id]) return;
-        lastFunded[id] = digest;
+        // `ComposableCoW` exposes the settlement domain separator it received at deployment.
+        bytes32 digest = GPv2Order.hash(order, COMPOSABLE_COW.domainSeparator());
+        if (funded[id][digest]) return;
+        funded[id][digest] = true;
 
         order.sellToken.safeTransferFrom(schedule.funder, schedule.owner, order.sellAmount);
         emit Pulled(id, digest, order.sellAmount);

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -2,12 +2,15 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import {IERC20, GPv2Order} from "cowprotocol/contracts/libraries/GPv2Order.sol";
+import {GPv2SafeERC20} from "cowprotocol/contracts/libraries/GPv2SafeERC20.sol";
 
 import {ComposableCoW} from "src/ComposableCoW.sol";
 import {IConditionalOrder, IConditionalOrderGenerator} from "src/interfaces/IConditionalOrder.sol";
 
 /// @title ComposableCowPoller - Just-in-time funding for composable conditional orders.
 contract ComposableCowPoller {
+    using GPv2SafeERC20 for IERC20;
+
     ComposableCoW public immutable composableCow;
 
     /// @notice Parameters for a JIT funding schedule.
@@ -116,7 +119,7 @@ contract ComposableCowPoller {
         if (digest == lastFunded[id]) return;
         lastFunded[id] = digest;
 
-        order.sellToken.transferFrom(schedule.funder, schedule.owner, order.sellAmount);
+        order.sellToken.safeTransferFrom(schedule.funder, schedule.owner, order.sellAmount);
         emit Pulled(id, digest, order.sellAmount);
     }
 }

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -39,9 +39,15 @@ contract ComposableCowPoller {
     /// @dev `id => digest => funded`. History survives schedule updates so an old order cannot be replayed.
     mapping(bytes32 => mapping(bytes32 => bool)) public funded;
 
-    /// @notice Thrown when someone other than the schedule funder registers or updates a schedule.
+    /// @notice Thrown when someone other than the schedule funder registers, updates, or revokes a schedule.
     error OnlyFunder();
+
+    /// @notice Thrown when polling an ID that has no registered schedule, because it was never
+    ///         registered or has since been revoked.
     error NoSchedule();
+
+    /// @notice Thrown when the schedule's conditional order is not authorised in `ComposableCoW`,
+    ///         either because it was never created or because it was removed.
     error OrderNotLive();
 
     /// @notice Emitted when a schedule is registered or updated.
@@ -49,6 +55,11 @@ contract ComposableCowPoller {
     /// @param owner The conditional-order owner and pull destination.
     /// @param funder The token source that registered the schedule.
     event ScheduleRegistered(bytes32 indexed id, address indexed owner, address indexed funder);
+
+    /// @notice Emitted when an order's sell amount is moved from the funder to the owner.
+    /// @param id The deterministic key of the schedule that was polled.
+    /// @param orderDigest The EIP-712 digest of the funded order, unique per part of the schedule.
+    /// @param amount The amount of `sellToken` transferred.
     event Pulled(bytes32 indexed id, bytes32 orderDigest, uint256 amount);
 
     constructor(ComposableCoW _composableCow) {

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -75,6 +75,8 @@ contract ComposableCowPoller {
     /// @dev Registering the same funder, handler, owner, and salt replaces the stored schedule.
     ///      Only the funds source may register, and the ID is namespaced by the funder. Funding
     ///      history is preserved across updates; use a new salt for a new logical schedule.
+    ///      A zero `owner` or `handler` needs no check: `pollFunds` requires
+    ///      `singleOrders[owner][ctx]`, which neither can ever satisfy.
     /// @param schedule The schedule to store.
     /// @return id The deterministic key of the stored schedule.
     function register(Schedule calldata schedule) external returns (bytes32 id) {

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
+import {GPv2Order} from "cowprotocol/contracts/libraries/GPv2Order.sol";
+
 import {IConditionalOrder, IValueFactory, BaseComposableCoWTest} from "test/ComposableCoW.base.t.sol";
 
 import {TWAP} from "src/types/twap/TWAP.sol";
@@ -201,31 +203,6 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         poller.revoke(id);
     }
 
-    /// @dev A single poll moves exactly the current part into the owner.
-    function test_pollFunds_fundsCurrentPart() public {
-        (, bytes32 ctx, bytes32 id) = _setupSchedule();
-        vm.warp(_t0(ctx));
-
-        assertEq(
-            token0.balanceOf(address(safe1)),
-            0,
-            "owner empty before pull"
-        );
-
-        poller.pollFunds(id);
-
-        assertEq(
-            token0.balanceOf(address(safe1)),
-            PART,
-            "owner funded with exactly one part"
-        );
-        assertEq(
-            token0.balanceOf(funder),
-            PART * N - PART,
-            "exactly one part left the funder"
-        );
-    }
-
     /// @dev Funds move unconditionally: even if the owner already holds a balance (e.g. from another
     ///      concurrent order), the full part is still pulled, so orders never share funding.
     function test_pollFunds_movesFullAmountUnconditionally() public {
@@ -233,36 +210,81 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         vm.warp(_t0(ctx));
 
         // The owner already holds an unrelated balance (e.g. funded for another order).
-        deal(address(token0), address(safe1), PART);
+        deal(address(token0), address(safe1), TWAP_PART_AMOUNT);
 
         poller.pollFunds(id);
 
         assertEq(
-            token0.balanceOf(address(safe1)),
-            PART * 2,
-            "full part pulled on top of the existing balance"
+            token0.balanceOf(address(safe1)), TWAP_PART_AMOUNT * 2, "full part pulled on top of the existing balance"
         );
-        assertEq(
-            token0.balanceOf(funder),
-            PART * N - PART,
-            "a full part left the funder"
-        );
+        assertEq(token0.balanceOf(funder), TWAP_PART_AMOUNT * N - TWAP_PART_AMOUNT, "a full part left the funder");
     }
 
-    /// @dev Repeated calls for the same part are a no-op (guarded by the order digest).
-    function test_pollFunds_idempotentWithinPart() public {
+    /// @dev A repeated call in the same part is a no-op, even after settlement drains the owner.
+    function test_pollFunds_idempotentWithinPartAfterSettlement() public {
         (, bytes32 ctx, bytes32 id) = _setupSchedule();
         vm.warp(_t0(ctx));
 
         poller.pollFunds(id);
+
+        vm.prank(address(safe1));
+        assertTrue(token0.transfer(bob.addr, TWAP_PART_AMOUNT), "part settled");
+        assertEq(token0.balanceOf(address(safe1)), 0, "part settled");
+
         poller.pollFunds(id); // no-op: this part has already been funded
 
-        assertEq(
-            token0.balanceOf(address(safe1)),
-            PART,
-            "still exactly one part"
+        assertEq(token0.balanceOf(address(safe1)), 0, "next part not funded early");
+        assertEq(token0.balanceOf(funder), TWAP_PART_AMOUNT * N - TWAP_PART_AMOUNT, "no extra pull");
+    }
+
+    /// @dev A handler returning A, then B, then A cannot refund A, even after schedule registration.
+    function test_pollFunds_doesNotRefundEarlierDigestAfterReregister() public {
+        (, bytes32 ctx, bytes32 id) = _setupSchedule();
+        vm.warp(_t0(ctx));
+
+        bytes memory staticInput = abi.encode(_bundle());
+        bytes memory handlerCall = abi.encodeCall(
+            IConditionalOrderGenerator.getTradeableOrder, (address(safe1), address(poller), ctx, staticInput, bytes(""))
         );
-        assertEq(token0.balanceOf(funder), PART * N - PART, "no extra pull");
+        GPv2Order.Data memory orderA =
+            twap.getTradeableOrder(address(safe1), address(poller), ctx, staticInput, bytes(""));
+        GPv2Order.Data memory orderB = abi.decode(abi.encode(orderA), (GPv2Order.Data));
+        orderB.appData = keccak256("second valid order");
+
+        vm.mockCall(address(twap), handlerCall, abi.encode(orderA));
+        poller.pollFunds(id);
+        vm.prank(address(safe1));
+        assertTrue(token0.transfer(bob.addr, TWAP_PART_AMOUNT), "first order settled");
+
+        vm.clearMockedCalls();
+        vm.mockCall(address(twap), handlerCall, abi.encode(orderB));
+        poller.pollFunds(id);
+        vm.prank(address(safe1));
+        assertTrue(token0.transfer(bob.addr, TWAP_PART_AMOUNT), "second order settled");
+
+        vm.prank(funder);
+        assertEq(
+            poller.register(
+                ComposableCowPoller.Schedule({
+                    handler: IConditionalOrderGenerator(address(twap)),
+                    funder: funder,
+                    owner: address(safe1),
+                    salt: SALT,
+                    staticInput: staticInput
+                })
+            ),
+            id,
+            "same schedule id"
+        );
+
+        vm.clearMockedCalls();
+        vm.mockCall(address(twap), handlerCall, abi.encode(orderA));
+        poller.pollFunds(id);
+
+        assertEq(token0.balanceOf(address(safe1)), 0, "first order not funded twice");
+        assertEq(token0.balanceOf(funder), TWAP_PART_AMOUNT, "only two distinct orders funded");
+        assertTrue(poller.funded(id, GPv2Order.hash(orderA, composableCow.domainSeparator())));
+        assertTrue(poller.funded(id, GPv2Order.hash(orderB, composableCow.domainSeparator())));
     }
 
     /// @dev A failed ERC-20 transfer must not mark this part as funded.
@@ -272,19 +294,12 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
 
         vm.mockCall(
             address(token0),
-            abi.encodeWithSelector(
-                token0.transferFrom.selector,
-                funder,
-                address(safe1),
-                PART
-            ),
+            abi.encodeWithSelector(token0.transferFrom.selector, funder, address(safe1), TWAP_PART_AMOUNT),
             abi.encode(false)
         );
 
         vm.expectRevert(bytes("GPv2: failed transferFrom"));
         poller.pollFunds(id);
-
-        assertEq(poller.lastFunded(id), bytes32(0), "failed pull is not recorded");
     }
 
     /// @dev The headline flow: each part is funded JIT and the owner holds nothing in between.
@@ -295,59 +310,20 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         for (uint256 part = 0; part < N; part++) {
             vm.warp(t0 + part * FREQ);
 
-            assertEq(
-                token0.balanceOf(address(safe1)),
-                0,
-                "owner empty before part"
-            );
+            assertEq(token0.balanceOf(address(safe1)), 0, "owner empty before part");
             poller.pollFunds(id);
-            assertEq(token0.balanceOf(address(safe1)), PART, "part funded");
+            assertEq(token0.balanceOf(address(safe1)), TWAP_PART_AMOUNT, "part funded");
 
             // Simulate the part settling: the owner's balance is consumed.
             vm.prank(address(safe1));
-            token0.transfer(bob.addr, PART);
+            assertTrue(token0.transfer(bob.addr, TWAP_PART_AMOUNT), "part settled");
 
             assertEq(
                 token0.balanceOf(funder),
-                PART * N - PART * (part + 1),
+                TWAP_PART_AMOUNT * N - TWAP_PART_AMOUNT * (part + 1),
                 "one part funded per window"
             );
         }
-    }
-
-    /// @dev The anti-premature-execution guard: once a part is funded, the *next* part's funds
-    ///      cannot be pulled until time advances into its window — even after the part settles and
-    ///      drains the owner. Without the per-order guard, the drained owner would be refilled
-    ///      immediately and that balance would be sold as the next part, a full interval early.
-    function test_pollFunds_cannotFundFuturePartEarly() public {
-        (, bytes32 ctx, bytes32 id) = _setupSchedule();
-        vm.warp(_t0(ctx)); // part 0 window
-
-        poller.pollFunds(id);
-        assertEq(token0.balanceOf(address(safe1)), PART, "part 0 funded");
-
-        // Simulate the part settling: the owner's balance is consumed.
-        vm.prank(address(safe1));
-        token0.transfer(bob.addr, PART);
-        assertEq(
-            token0.balanceOf(address(safe1)),
-            0,
-            "owner drained by the fill"
-        );
-
-        // Still inside part 0's window: a fresh pull must NOT refill.
-        poller.pollFunds(id);
-
-        assertEq(
-            token0.balanceOf(address(safe1)),
-            0,
-            "next part not funded early"
-        );
-        assertEq(
-            token0.balanceOf(funder),
-            PART * N - PART,
-            "exactly one part ever left the funder"
-        );
     }
 
     /// @dev The pull is bounded to the schedule window: after it ends, `getTradeableOrder` reverts.

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -31,7 +31,7 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
 
         twap = new TWAP(composableCow);
         currentBlockTimestampFactory = new CurrentBlockTimestampFactory();
-        poller = new ComposableCowPoller();
+        poller = new ComposableCowPoller(composableCow);
         funder = makeAddr("funder");
 
         // The owner (safe1) starts with no sell token: funds arrive just-in-time.
@@ -60,7 +60,7 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
     /// @dev Creates a JIT-funded TWAP: order via context, the funder funds + approves the poller,
     ///      and the schedule is registered. Returns the order's cabinet key `ctx`
     ///      (`ComposableCoW.hash(params)`, used for cabinet/remove) and the appData-independent
-    ///      poller schedule key `id` (used for topUp/revoke).
+    ///      poller schedule key `id` (used for pollFunds/revoke).
     function _setupSchedule()
         internal
         returns (IConditionalOrder.ConditionalOrderParams memory params, bytes32 ctx, bytes32 id)
@@ -101,6 +101,12 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
     function _register(ComposableCowPoller.Schedule memory schedule) internal returns (bytes32 id) {
         vm.prank(funder);
         id = poller.register(schedule);
+    }
+
+    /// @dev The order's resolved start time `t0`, read back from the cabinet where
+    ///      `createWithContext` stored it via `CurrentBlockTimestampFactory`.
+    function _t0(bytes32 ctx) internal view returns (uint256) {
+        return uint256(composableCow.cabinet(address(safe1), ctx));
     }
 
     /// @dev A registered schedule is stored under its appData-independent id.
@@ -193,5 +199,159 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
 
         vm.expectRevert(ComposableCowPoller.OnlyFunder.selector);
         poller.revoke(id);
+    }
+
+    /// @dev A single poll moves exactly the current part into the owner.
+    function test_pollFunds_fundsCurrentPart() public {
+        (, bytes32 ctx, bytes32 id) = _setupSchedule();
+        vm.warp(_t0(ctx));
+
+        assertEq(
+            token0.balanceOf(address(safe1)),
+            0,
+            "owner empty before pull"
+        );
+
+        poller.pollFunds(id);
+
+        assertEq(
+            token0.balanceOf(address(safe1)),
+            PART,
+            "owner funded with exactly one part"
+        );
+        assertEq(
+            token0.balanceOf(funder),
+            PART * N - PART,
+            "exactly one part left the funder"
+        );
+    }
+
+    /// @dev Funds move unconditionally: even if the owner already holds a balance (e.g. from another
+    ///      concurrent order), the full part is still pulled, so orders never share funding.
+    function test_pollFunds_movesFullAmountUnconditionally() public {
+        (, bytes32 ctx, bytes32 id) = _setupSchedule();
+        vm.warp(_t0(ctx));
+
+        // The owner already holds an unrelated balance (e.g. funded for another order).
+        deal(address(token0), address(safe1), PART);
+
+        poller.pollFunds(id);
+
+        assertEq(
+            token0.balanceOf(address(safe1)),
+            PART * 2,
+            "full part pulled on top of the existing balance"
+        );
+        assertEq(
+            token0.balanceOf(funder),
+            PART * N - PART,
+            "a full part left the funder"
+        );
+    }
+
+    /// @dev Repeated calls for the same part are a no-op (guarded by the order digest).
+    function test_pollFunds_idempotentWithinPart() public {
+        (, bytes32 ctx, bytes32 id) = _setupSchedule();
+        vm.warp(_t0(ctx));
+
+        poller.pollFunds(id);
+        poller.pollFunds(id); // no-op: this part has already been funded
+
+        assertEq(
+            token0.balanceOf(address(safe1)),
+            PART,
+            "still exactly one part"
+        );
+        assertEq(token0.balanceOf(funder), PART * N - PART, "no extra pull");
+    }
+
+    /// @dev The headline flow: each part is funded JIT and the owner holds nothing in between.
+    function test_pollFunds_fundsEachPartAcrossSchedule() public {
+        (, bytes32 ctx, bytes32 id) = _setupSchedule();
+        uint256 t0 = _t0(ctx);
+
+        for (uint256 part = 0; part < N; part++) {
+            vm.warp(t0 + part * FREQ);
+
+            assertEq(
+                token0.balanceOf(address(safe1)),
+                0,
+                "owner empty before part"
+            );
+            poller.pollFunds(id);
+            assertEq(token0.balanceOf(address(safe1)), PART, "part funded");
+
+            // Simulate the part settling: the owner's balance is consumed.
+            vm.prank(address(safe1));
+            token0.transfer(bob.addr, PART);
+
+            assertEq(
+                token0.balanceOf(funder),
+                PART * N - PART * (part + 1),
+                "one part funded per window"
+            );
+        }
+    }
+
+    /// @dev The anti-premature-execution guard: once a part is funded, the *next* part's funds
+    ///      cannot be pulled until time advances into its window — even after the part settles and
+    ///      drains the owner. Without the per-order guard, the drained owner would be refilled
+    ///      immediately and that balance would be sold as the next part, a full interval early.
+    function test_pollFunds_cannotFundFuturePartEarly() public {
+        (, bytes32 ctx, bytes32 id) = _setupSchedule();
+        vm.warp(_t0(ctx)); // part 0 window
+
+        poller.pollFunds(id);
+        assertEq(token0.balanceOf(address(safe1)), PART, "part 0 funded");
+
+        // Simulate the part settling: the owner's balance is consumed.
+        vm.prank(address(safe1));
+        token0.transfer(bob.addr, PART);
+        assertEq(
+            token0.balanceOf(address(safe1)),
+            0,
+            "owner drained by the fill"
+        );
+
+        // Still inside part 0's window: a fresh pull must NOT refill.
+        poller.pollFunds(id);
+
+        assertEq(
+            token0.balanceOf(address(safe1)),
+            0,
+            "next part not funded early"
+        );
+        assertEq(
+            token0.balanceOf(funder),
+            PART * N - PART,
+            "exactly one part ever left the funder"
+        );
+    }
+
+    /// @dev The pull is bounded to the schedule window: after it ends, `getTradeableOrder` reverts.
+    function test_pollFunds_RevertWhen_scheduleEnded() public {
+        (, bytes32 ctx, bytes32 id) = _setupSchedule();
+        vm.warp(_t0(ctx) + N * FREQ);
+
+        vm.expectRevert(); // IConditionalOrder.OrderNotValid(...) from the handler
+        poller.pollFunds(id);
+    }
+
+    /// @dev An unregistered schedule cannot be polled.
+    function test_pollFunds_RevertWhen_noSchedule() public {
+        vm.expectRevert(ComposableCowPoller.NoSchedule.selector);
+        poller.pollFunds(keccak256("unknown"));
+    }
+
+    /// @dev Cancelling the order flips `singleOrders` false, which disables the poller for free.
+    function test_remove_killsPoller() public {
+        (, bytes32 ctx, bytes32 id) = _setupSchedule();
+        vm.warp(_t0(ctx));
+
+        vm.prank(address(safe1));
+        composableCow.remove(ctx);
+
+        vm.expectRevert(ComposableCowPoller.OrderNotLive.selector);
+        poller.pollFunds(id);
     }
 }

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -265,6 +265,28 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         assertEq(token0.balanceOf(funder), PART * N - PART, "no extra pull");
     }
 
+    /// @dev A failed ERC-20 transfer must not mark this part as funded.
+    function test_pollFunds_RevertWhen_transferFromReturnsFalse() public {
+        (, bytes32 ctx, bytes32 id) = _setupSchedule();
+        vm.warp(_t0(ctx));
+
+        vm.mockCall(
+            address(token0),
+            abi.encodeWithSelector(
+                token0.transferFrom.selector,
+                funder,
+                address(safe1),
+                PART
+            ),
+            abi.encode(false)
+        );
+
+        vm.expectRevert(bytes("GPv2: failed transferFrom"));
+        poller.pollFunds(id);
+
+        assertEq(poller.lastFunded(id), bytes32(0), "failed pull is not recorded");
+    }
+
     /// @dev The headline flow: each part is funded JIT and the owner holds nothing in between.
     function test_pollFunds_fundsEachPartAcrossSchedule() public {
         (, bytes32 ctx, bytes32 id) = _setupSchedule();


### PR DESCRIPTION
Part of #121. Follows on https://github.com/cowprotocol/composable-cow/pull/124

## Note on the merge / approvals
This PR is merged with 2 approvals, even though it doesnt show. Apparently because of the settings in this repo, when I merge and squashed a dependent PR it dismissed the 2 approvals:
```
{at: 19:32:32, was: "approved", reason: "The base branch was changed.", by: igorroncevic}
{at: 19:32:32, was: "approved", reason: "The base branch was changed.", by: kaze-cow}
S
```
However, the commits are the exact ones that were approved, so merged as it is. 

## What
This is the PR that adding the main feature.

Adds the just-in-time funding entry point (`pollFunds`). This is the function that will be called by the hooks to poll the funds.

The method will do a series of validations:
- The schedule was registered,
- The polling hasn't been done yet for the current order. For checking this, it will check with the pre-registered handler to generate an order, and from it, derices the `orderUid`. This is how we can reuse the logic from the handlers to be used for the polling too. For example, in TWAP makes sure we don't pull twice for the same leg.
- It also checks the composable cow order has been authorised . This way, cancellations of composable cow orders will also work out of the box. 


## Topup vs pollFunds
Initially in my first draft I implemented a method to top up the account (adding whatever balance that is missing in order to be able to fullfull the `order.sellAmount`.

I decided to rename to `pollFunds` to move the funds unconditionally (don't check the balance. This way, we can reuse the same trader contract for more concurrent orders, and we don't run into race conditions where some order uses the funds of some other.


## Test plan
```bash
forge test --match-contract ComposableCowPollerTest -vv
```

Test should pass