### PR TITLE
feat(poller): authorize funder CowShed

### DIFF
--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -7,20 +7,25 @@ import {GPv2SafeERC20} from "cowprotocol/contracts/libraries/GPv2SafeERC20.sol";
 import {ComposableCoW} from "src/ComposableCoW.sol";
 import {IConditionalOrder, IConditionalOrderGenerator} from "src/interfaces/IConditionalOrder.sol";
 
+interface ICowShedFactory {
+    function proxyOf(address owner) external view returns (address);
+}
+
 /// @title ComposableCowPoller - Just-in-time funding for composable conditional orders.
 contract ComposableCowPoller {
     using GPv2SafeERC20 for IERC20;
 
     /// @dev `ComposableCoW` stores the settlement domain separator supplied at deployment.
     ComposableCoW public immutable COMPOSABLE_COW;
+    ICowShedFactory public immutable COW_SHED_FACTORY;
 
     /// @notice Parameters for a JIT funding schedule.
     /// @dev A schedule is uniquely identified by its funder, handler, owner, and salt.
     struct Schedule {
         /// @notice The conditional-order handler to poll, such as the TWAP type.
         IConditionalOrderGenerator handler;
-        /// @notice The address allowed to register this schedule and later debited for sell tokens.
-        /// @dev It can be an EOA or contract and may be the same address as `owner`.
+        /// @notice The address debited for sell tokens and authorized to manage this schedule.
+        /// @dev The funder or its factory-derived CowShed may register and revoke.
         address funder;
         /// @notice The address that owns the ComposableCoW conditional order and receives the pulled funds.
         /// @dev It can be an EOA or contract and may be the same address as `funder`.
@@ -39,8 +44,9 @@ contract ComposableCowPoller {
     /// @dev `id => digest => funded`. History survives schedule updates so an old order cannot be replayed.
     mapping(bytes32 => mapping(bytes32 => bool)) public funded;
 
-    /// @notice Thrown when someone other than the schedule funder registers or updates a schedule.
-    error OnlyFunder();
+    error InvalidComposableCow();
+    error InvalidCowShedFactory();
+    error UnauthorizedCaller();
     error NoSchedule();
     error OrderNotLive();
 
@@ -51,8 +57,11 @@ contract ComposableCowPoller {
     event ScheduleRegistered(bytes32 indexed id, address indexed owner, address indexed funder);
     event Pulled(bytes32 indexed id, bytes32 orderDigest, uint256 amount);
 
-    constructor(ComposableCoW _composableCow) {
-        COMPOSABLE_COW = _composableCow;
+    constructor(ComposableCoW composableCow, ICowShedFactory cowShedFactory) {
+        if (address(composableCow).code.length == 0) revert InvalidComposableCow();
+        if (address(cowShedFactory).code.length == 0) revert InvalidCowShedFactory();
+        COMPOSABLE_COW = composableCow;
+        COW_SHED_FACTORY = cowShedFactory;
     }
 
     /// @notice Emitted when a schedule is revoked.
@@ -73,24 +82,29 @@ contract ComposableCowPoller {
 
     /// @notice Registers or updates a schedule.
     /// @dev Registering the same funder, handler, owner, and salt replaces the stored schedule.
-    ///      Only the funds source may register, and the ID is namespaced by the funder. Funding
-    ///      history is preserved across updates; use a new salt for a new logical schedule.
+    ///      Only the funder or its factory-derived CowShed may register, and the ID is namespaced
+    ///      by the funder. Funding history is preserved across updates; use a new salt for a new
+    ///      logical schedule.
     /// @param schedule The schedule to store.
     /// @return id The deterministic key of the stored schedule.
     function register(Schedule calldata schedule) external returns (bytes32 id) {
-        if (msg.sender != schedule.funder) revert OnlyFunder();
+        if (!_isAuthorizedCaller(schedule.funder)) revert UnauthorizedCaller();
         id = scheduleId(schedule);
         schedules[id] = schedule;
         emit ScheduleRegistered(id, schedule.owner, schedule.funder);
     }
 
-    /// @notice Revoke a schedule. Only the funds source may do so. A standing ERC-20 allowance
-    ///         should be revoked separately to fully close the surface.
+    /// @notice Revoke a schedule. Only the funder or its factory-derived CowShed may do so.
+    ///         A standing ERC-20 allowance should be revoked separately to fully close the surface.
     function revoke(bytes32 id) external {
         Schedule storage schedule = schedules[id];
-        if (msg.sender != schedule.funder) revert OnlyFunder();
+        if (!_isAuthorizedCaller(schedule.funder)) revert UnauthorizedCaller();
         emit ScheduleRevoked(id, schedule.owner, schedule.funder);
         delete schedules[id];
+    }
+
+    function _isAuthorizedCaller(address funder) internal view returns (bool) {
+        return funder != address(0) && (msg.sender == funder || msg.sender == COW_SHED_FACTORY.proxyOf(funder));
     }
 
     /// @notice Move the current order's `sellAmount` from the funder to the owner. Permissionless.

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -7,20 +7,25 @@ import {GPv2SafeERC20} from "cowprotocol/contracts/libraries/GPv2SafeERC20.sol";
 import {ComposableCoW} from "src/ComposableCoW.sol";
 import {IConditionalOrder, IConditionalOrderGenerator} from "src/interfaces/IConditionalOrder.sol";
 
+interface ICowShedFactory {
+    function proxyOf(address owner) external view returns (address);
+}
+
 /// @title ComposableCowPoller - Just-in-time funding for composable conditional orders.
 contract ComposableCowPoller {
     using GPv2SafeERC20 for IERC20;
 
     /// @dev `ComposableCoW` stores the settlement domain separator supplied at deployment.
     ComposableCoW public immutable COMPOSABLE_COW;
+    ICowShedFactory public immutable COW_SHED_FACTORY;
 
     /// @notice Parameters for a JIT funding schedule.
     /// @dev A schedule is uniquely identified by its funder, handler, owner, and salt.
     struct Schedule {
         /// @notice The conditional-order handler to poll, such as the TWAP type.
         IConditionalOrderGenerator handler;
-        /// @notice The address allowed to register this schedule and later debited for sell tokens.
-        /// @dev It can be an EOA or contract and may be the same address as `owner`.
+        /// @notice The address debited for sell tokens and authorized to manage this schedule.
+        /// @dev The funder or its factory-derived CowShed may register and revoke.
         address funder;
         /// @notice The address that owns the ComposableCoW conditional order and receives the pulled funds.
         /// @dev It can be an EOA or contract and may be the same address as `funder`.
@@ -39,8 +44,15 @@ contract ComposableCowPoller {
     /// @dev `id => digest => funded`. History survives schedule updates so an old order cannot be replayed.
     mapping(bytes32 => mapping(bytes32 => bool)) public funded;
 
-    /// @notice Thrown when someone other than the schedule funder registers, updates, or revokes a schedule.
-    error OnlyFunder();
+    /// @notice Thrown when the `ComposableCoW` address supplied at deployment has no code.
+    error InvalidComposableCow();
+
+    /// @notice Thrown when the CowShed factory address supplied at deployment has no code.
+    error InvalidCowShedFactory();
+
+    /// @notice Thrown when someone other than the schedule funder or its factory-derived CowShed
+    ///         registers, updates, or revokes a schedule.
+    error UnauthorizedCaller();
 
     /// @notice Thrown when polling an ID that has no registered schedule, because it was never
     ///         registered or has since been revoked.
@@ -62,8 +74,11 @@ contract ComposableCowPoller {
     /// @param amount The amount of `sellToken` transferred.
     event Pulled(bytes32 indexed id, bytes32 orderDigest, uint256 amount);
 
-    constructor(ComposableCoW _composableCow) {
-        COMPOSABLE_COW = _composableCow;
+    constructor(ComposableCoW composableCow, ICowShedFactory cowShedFactory) {
+        if (address(composableCow).code.length == 0) revert InvalidComposableCow();
+        if (address(cowShedFactory).code.length == 0) revert InvalidCowShedFactory();
+        COMPOSABLE_COW = composableCow;
+        COW_SHED_FACTORY = cowShedFactory;
     }
 
     /// @notice Emitted when a schedule is revoked.
@@ -84,26 +99,31 @@ contract ComposableCowPoller {
 
     /// @notice Registers or updates a schedule.
     /// @dev Registering the same funder, handler, owner, and salt replaces the stored schedule.
-    ///      Only the funds source may register, and the ID is namespaced by the funder. Funding
-    ///      history is preserved across updates; use a new salt for a new logical schedule.
+    ///      Only the funder or its factory-derived CowShed may register, and the ID is namespaced
+    ///      by the funder. Funding history is preserved across updates; use a new salt for a new
+    ///      logical schedule.
     ///      A zero `owner` or `handler` needs no check: `pollFunds` requires
     ///      `singleOrders[owner][ctx]`, which neither can ever satisfy.
     /// @param schedule The schedule to store.
     /// @return id The deterministic key of the stored schedule.
     function register(Schedule calldata schedule) external returns (bytes32 id) {
-        if (msg.sender != schedule.funder) revert OnlyFunder();
+        if (!_isAuthorizedCaller(schedule.funder)) revert UnauthorizedCaller();
         id = scheduleId(schedule);
         schedules[id] = schedule;
         emit ScheduleRegistered(id, schedule.owner, schedule.funder);
     }
 
-    /// @notice Revoke a schedule. Only the funds source may do so. A standing ERC-20 allowance
-    ///         should be revoked separately to fully close the surface.
+    /// @notice Revoke a schedule. Only the funder or its factory-derived CowShed may do so.
+    ///         A standing ERC-20 allowance should be revoked separately to fully close the surface.
     function revoke(bytes32 id) external {
         Schedule storage schedule = schedules[id];
-        if (msg.sender != schedule.funder) revert OnlyFunder();
+        if (!_isAuthorizedCaller(schedule.funder)) revert UnauthorizedCaller();
         emit ScheduleRevoked(id, schedule.owner, schedule.funder);
         delete schedules[id];
+    }
+
+    function _isAuthorizedCaller(address funder) internal view returns (bool) {
+        return funder != address(0) && (msg.sender == funder || msg.sender == COW_SHED_FACTORY.proxyOf(funder));
     }
 
     /// @notice Move the current order's `sellAmount` from the funder to the owner. Permissionless.

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -44,12 +44,6 @@ contract ComposableCowPoller {
     /// @dev `id => digest => funded`. History survives schedule updates so an old order cannot be replayed.
     mapping(bytes32 => mapping(bytes32 => bool)) public funded;
 
-    /// @notice Thrown when the `ComposableCoW` address supplied at deployment has no code.
-    error InvalidComposableCow();
-
-    /// @notice Thrown when the CowShed factory address supplied at deployment has no code.
-    error InvalidCowShedFactory();
-
     /// @notice Thrown when someone other than the schedule funder or its factory-derived CowShed
     ///         registers, updates, or revokes a schedule.
     error UnauthorizedCaller();
@@ -75,8 +69,6 @@ contract ComposableCowPoller {
     event Pulled(bytes32 indexed id, bytes32 orderDigest, uint256 amount);
 
     constructor(ComposableCoW composableCow, ICowShedFactory cowShedFactory) {
-        if (address(composableCow).code.length == 0) revert InvalidComposableCow();
-        if (address(cowShedFactory).code.length == 0) revert InvalidCowShedFactory();
         COMPOSABLE_COW = composableCow;
         COW_SHED_FACTORY = cowShedFactory;
     }
@@ -122,6 +114,11 @@ contract ComposableCowPoller {
         delete schedules[id];
     }
 
+    /// @notice Checks whether the caller may manage a funder's schedule.
+    /// @dev Authorizes the funder or its canonical CowShed derived by `COW_SHED_FACTORY`.
+    ///      The zero address is rejected because it represents a missing schedule.
+    /// @param funder The token owner whose schedule is being managed.
+    /// @return Whether the caller is authorized.
     function _isAuthorizedCaller(address funder) internal view returns (bool) {
         return funder != address(0) && (msg.sender == funder || msg.sender == COW_SHED_FACTORY.proxyOf(funder));
     }

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -5,11 +5,20 @@ import {GPv2Order} from "cowprotocol/contracts/libraries/GPv2Order.sol";
 
 import {IConditionalOrder, IValueFactory, BaseComposableCoWTest} from "test/ComposableCoW.base.t.sol";
 
+import {ComposableCoW} from "src/ComposableCoW.sol";
 import {TWAP} from "src/types/twap/TWAP.sol";
 import {TWAPOrder} from "src/types/twap/libraries/TWAPOrder.sol";
-import {ComposableCowPoller} from "src/types/ComposableCowPoller.sol";
+import {ComposableCowPoller, ICowShedFactory} from "src/types/ComposableCowPoller.sol";
 import {CurrentBlockTimestampFactory} from "src/value_factories/CurrentBlockTimestampFactory.sol";
 import {IConditionalOrderGenerator} from "src/interfaces/IConditionalOrder.sol";
+
+contract CowShedFactoryMock {
+    mapping(address => address) public proxyOf;
+
+    function setProxy(address owner, address cowShed) external {
+        proxyOf[owner] = cowShed;
+    }
+}
 
 /// @title ComposableCowPoller unit tests
 /// @notice Exercises registering a schedule for a composable TWAP created via `createWithContext`.
@@ -22,10 +31,13 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
     bytes32 constant SECOND_SALT = keccak256("second twap");
 
     ComposableCowPoller poller;
+    CowShedFactoryMock cowShedFactory;
     IValueFactory currentBlockTimestampFactory;
 
     address funder;
+    address otherFunder;
 
+    event ScheduleRegistered(bytes32 indexed id, address indexed owner, address indexed funder);
     event ScheduleRevoked(bytes32 indexed id, address indexed owner, address indexed funder);
 
     function setUp() public virtual override(BaseComposableCoWTest) {
@@ -33,8 +45,12 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
 
         twap = new TWAP(composableCow);
         currentBlockTimestampFactory = new CurrentBlockTimestampFactory();
-        poller = new ComposableCowPoller(composableCow);
         funder = makeAddr("funder");
+        otherFunder = makeAddr("other funder");
+        cowShedFactory = new CowShedFactoryMock();
+        cowShedFactory.setProxy(funder, address(safe1));
+        cowShedFactory.setProxy(otherFunder, address(safe2));
+        poller = new ComposableCowPoller(composableCow, ICowShedFactory(address(cowShedFactory)));
 
         // The owner (safe1) starts with no sell token: funds arrive just-in-time.
         deal(address(token0), address(safe1), 0);
@@ -42,6 +58,30 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
 
     function test_deployment() public {
         assertTrue(address(poller).code.length > 0, "poller deployed");
+        assertEq(address(poller.COMPOSABLE_COW()), address(composableCow));
+        assertEq(address(poller.COW_SHED_FACTORY()), address(cowShedFactory));
+    }
+
+    function test_constructor_RevertWhen_composableCowIsZero() public {
+        vm.expectRevert(ComposableCowPoller.InvalidComposableCow.selector);
+        new ComposableCowPoller(ComposableCoW(address(0)), ICowShedFactory(address(cowShedFactory)));
+    }
+
+    function test_constructor_RevertWhen_composableCowHasNoCode() public {
+        vm.expectRevert(ComposableCowPoller.InvalidComposableCow.selector);
+        new ComposableCowPoller(
+            ComposableCoW(makeAddr("code-less ComposableCoW")), ICowShedFactory(address(cowShedFactory))
+        );
+    }
+
+    function test_constructor_RevertWhen_cowShedFactoryIsZero() public {
+        vm.expectRevert(ComposableCowPoller.InvalidCowShedFactory.selector);
+        new ComposableCowPoller(composableCow, ICowShedFactory(address(0)));
+    }
+
+    function test_constructor_RevertWhen_cowShedFactoryHasNoCode() public {
+        vm.expectRevert(ComposableCowPoller.InvalidCowShedFactory.selector);
+        new ComposableCowPoller(composableCow, ICowShedFactory(makeAddr("code-less CowShed factory")));
     }
 
     function _bundle() internal view returns (TWAPOrder.Data memory) {
@@ -76,10 +116,8 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         vm.prank(funder);
         token0.approve(address(poller), TWAP_PART_AMOUNT * N);
 
-        // Register the schedule (only the funder may do this). The schedule carries the handler,
-        // the funds source, the destination, the order's `salt` (so the poller can rebuild `ctx`
-        // on-chain) and its `staticInput`. The key is appData-independent so the funding hook can
-        // live in the order's own appData.
+        // Register as the funder EOA. Its official CowShed may also register. The schedule carries
+        // the handler, funds source, destination, and order data needed to rebuild `ctx` on-chain.
         ComposableCowPoller.Schedule memory schedule = _schedule(SALT, abi.encode(_bundle()));
         id = _register(schedule);
 
@@ -156,9 +194,9 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         assertEq(staticInput, updatedStaticInput, "replacement input stored");
     }
 
-    /// @dev Only the funds source may register a schedule that draws on its own funds.
-    function test_register_RevertWhen_notFunder() public {
-        vm.expectRevert(ComposableCowPoller.OnlyFunder.selector);
+    /// @dev An unrelated caller cannot register a schedule that draws on the funder's tokens.
+    function test_register_RevertWhen_unauthorizedCaller() public {
+        vm.expectRevert(ComposableCowPoller.UnauthorizedCaller.selector);
         poller.register(
             ComposableCowPoller.Schedule({
                 handler: IConditionalOrderGenerator(address(twap)),
@@ -168,6 +206,59 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
                 staticInput: abi.encode(_bundle())
             })
         );
+    }
+
+    /// @dev A funder's factory-derived CowShed can register and revoke its schedule.
+    function test_cowShed_canRegisterAndRevoke() public {
+        ComposableCowPoller.Schedule memory schedule = _schedule(SALT, abi.encode(_bundle()));
+        bytes32 id = poller.scheduleId(schedule);
+
+        vm.expectEmit(true, true, true, true, address(poller));
+        emit ScheduleRegistered(id, address(safe1), funder);
+        vm.prank(address(safe1));
+        poller.register(schedule);
+        (IConditionalOrderGenerator handler,,,,) = poller.schedules(id);
+        assertEq(address(handler), address(twap), "schedule registered");
+
+        vm.expectEmit(true, true, true, true, address(poller));
+        emit ScheduleRevoked(id, address(safe1), funder);
+        vm.prank(address(safe1));
+        poller.revoke(id);
+        (handler,,,,) = poller.schedules(id);
+        assertEq(address(handler), address(0), "schedule revoked");
+    }
+
+    function test_register_RevertWhen_funderIsZero() public {
+        address caller = makeAddr("zero funder CowShed");
+        cowShedFactory.setProxy(address(0), caller);
+        ComposableCowPoller.Schedule memory schedule = _schedule(SALT, abi.encode(_bundle()));
+        schedule.funder = address(0);
+
+        vm.expectRevert(ComposableCowPoller.UnauthorizedCaller.selector);
+        vm.prank(caller);
+        poller.register(schedule);
+    }
+
+    function test_register_RevertWhen_fakeCowShed() public {
+        vm.expectRevert(ComposableCowPoller.UnauthorizedCaller.selector);
+        vm.prank(makeAddr("fake CowShed"));
+        poller.register(_schedule(SALT, abi.encode(_bundle())));
+    }
+
+    function test_register_RevertWhen_otherUsersCowShed() public {
+        vm.expectRevert(ComposableCowPoller.UnauthorizedCaller.selector);
+        vm.prank(address(safe2));
+        poller.register(_schedule(SALT, abi.encode(_bundle())));
+    }
+
+    function test_register_RevertWhen_cowShedActsForDifferentFunder() public {
+        ComposableCowPoller.Schedule memory schedule = _schedule(SALT, abi.encode(_bundle()));
+        schedule.funder = otherFunder;
+        schedule.owner = address(safe2);
+
+        vm.expectRevert(ComposableCowPoller.UnauthorizedCaller.selector);
+        vm.prank(address(safe1));
+        poller.register(schedule);
     }
 
     /// @dev The funder can revoke, which clears the schedule.
@@ -195,11 +286,19 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         assertEq(staticInput, bytes(""), "static input cleared");
     }
 
-    /// @dev Only the funds source may revoke.
-    function test_revoke_RevertWhen_notFunder() public {
+    /// @dev An unrelated caller cannot revoke the funder's schedule.
+    function test_revoke_RevertWhen_unauthorizedCaller() public {
         (,, bytes32 id) = _setupSchedule();
 
-        vm.expectRevert(ComposableCowPoller.OnlyFunder.selector);
+        vm.expectRevert(ComposableCowPoller.UnauthorizedCaller.selector);
+        poller.revoke(id);
+    }
+
+    function test_revoke_RevertWhen_otherUsersCowShed() public {
+        (,, bytes32 id) = _setupSchedule();
+
+        vm.expectRevert(ComposableCowPoller.UnauthorizedCaller.selector);
+        vm.prank(address(safe2));
         poller.revoke(id);
     }
 

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -62,28 +62,6 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         assertEq(address(poller.COW_SHED_FACTORY()), address(cowShedFactory));
     }
 
-    function test_constructor_RevertWhen_composableCowIsZero() public {
-        vm.expectRevert(ComposableCowPoller.InvalidComposableCow.selector);
-        new ComposableCowPoller(ComposableCoW(address(0)), ICowShedFactory(address(cowShedFactory)));
-    }
-
-    function test_constructor_RevertWhen_composableCowHasNoCode() public {
-        vm.expectRevert(ComposableCowPoller.InvalidComposableCow.selector);
-        new ComposableCowPoller(
-            ComposableCoW(makeAddr("code-less ComposableCoW")), ICowShedFactory(address(cowShedFactory))
-        );
-    }
-
-    function test_constructor_RevertWhen_cowShedFactoryIsZero() public {
-        vm.expectRevert(ComposableCowPoller.InvalidCowShedFactory.selector);
-        new ComposableCowPoller(composableCow, ICowShedFactory(address(0)));
-    }
-
-    function test_constructor_RevertWhen_cowShedFactoryHasNoCode() public {
-        vm.expectRevert(ComposableCowPoller.InvalidCowShedFactory.selector);
-        new ComposableCowPoller(composableCow, ICowShedFactory(makeAddr("code-less CowShed factory")));
-    }
-
     function _bundle() internal view returns (TWAPOrder.Data memory) {
         return TWAPOrder.Data({
             sellToken: token0,


### PR DESCRIPTION
## What and why

Allow a funder’s canonical CowShed to register and revoke Poller schedules. This enables gasless JIT TWAP setup and cancellation while keeping direct funder calls working.

Related: #125

## Test

`forge test --match-contract ComposableCowPollerTest`
