### PR TITLE
feat(poller): log schedule fields on register

### DIFF
--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -51,8 +51,22 @@ contract ComposableCowPoller {
     /// @notice Emitted when a schedule is registered or updated.
     /// @param id The deterministic key of the schedule.
     /// @param owner The conditional-order owner and pull destination.
+    /// @dev `id` is a one-way hash, so the fields it commits to are logged alongside it: without
+    ///      them an indexer cannot recover the schedule from logs alone, nor tell an update apart
+    ///      from the registration it replaced. `staticInput` is logged as a hash rather than in
+    ///      full, since only its identity is needed to correlate a schedule with its order.
     /// @param funder The token source that registered the schedule.
-    event ScheduleRegistered(bytes32 indexed id, address indexed owner, address indexed funder);
+    /// @param handler The conditional-order handler that will be polled.
+    /// @param salt The salt namespacing this schedule for the funder, handler, and owner.
+    /// @param staticInputHash `keccak256` of the static input passed to the handler.
+    event ScheduleRegistered(
+        bytes32 indexed id,
+        address indexed owner,
+        address indexed funder,
+        IConditionalOrderGenerator handler,
+        bytes32 salt,
+        bytes32 staticInputHash
+    );
     event Pulled(bytes32 indexed id, bytes32 orderDigest, uint256 amount);
 
     constructor(ComposableCoW composableCow, ICowShedFactory cowShedFactory) {
@@ -87,7 +101,9 @@ contract ComposableCowPoller {
         if (!_isAuthorizedCaller(schedule.funder)) revert UnauthorizedCaller();
         id = scheduleId(schedule);
         schedules[id] = schedule;
-        emit ScheduleRegistered(id, schedule.owner, schedule.funder);
+        emit ScheduleRegistered(
+            id, schedule.owner, schedule.funder, schedule.handler, schedule.salt, keccak256(schedule.staticInput)
+        );
     }
 
     /// @notice Revoke a schedule. Only the funder or its factory-derived CowShed may do so.

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -37,7 +37,14 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
     address funder;
     address otherFunder;
 
-    event ScheduleRegistered(bytes32 indexed id, address indexed owner, address indexed funder);
+    event ScheduleRegistered(
+        bytes32 indexed id,
+        address indexed owner,
+        address indexed funder,
+        IConditionalOrderGenerator handler,
+        bytes32 salt,
+        bytes32 staticInputHash
+    );
     event ScheduleRevoked(bytes32 indexed id, address indexed owner, address indexed funder);
 
     function setUp() public virtual override(BaseComposableCoWTest) {
@@ -172,6 +179,34 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         assertEq(staticInput, updatedStaticInput, "replacement input stored");
     }
 
+    /// @dev The log must distinguish an update from the registration it replaces. Two schedules
+    ///      sharing an id but describing different orders share every indexed topic, so the
+    ///      `staticInputHash` in the data is the only thing that tells them apart on-chain.
+    function test_register_logIdentifiesTheReplacedOrder() public {
+        bytes memory firstInput = abi.encode(_bundle());
+        ComposableCowPoller.Schedule memory first = _schedule(SALT, firstInput);
+        bytes32 id = poller.scheduleId(first);
+
+        vm.expectEmit(true, true, true, true, address(poller));
+        emit ScheduleRegistered(
+            id, address(safe1), funder, IConditionalOrderGenerator(address(twap)), SALT, keccak256(firstInput)
+        );
+        _register(first);
+
+        // A genuinely different order, not just an appData refresh.
+        TWAPOrder.Data memory other = _bundle();
+        other.partSellAmount = TWAP_PART_AMOUNT * 2;
+        bytes memory secondInput = abi.encode(other);
+        assertTrue(keccak256(firstInput) != keccak256(secondInput), "inputs differ");
+
+        // Same id, same indexed topics: only `staticInputHash` reveals the clobber.
+        vm.expectEmit(true, true, true, true, address(poller));
+        emit ScheduleRegistered(
+            id, address(safe1), funder, IConditionalOrderGenerator(address(twap)), SALT, keccak256(secondInput)
+        );
+        assertEq(_register(_schedule(SALT, secondInput)), id, "same id as the schedule it replaced");
+    }
+
     /// @dev An unrelated caller cannot register a schedule that draws on the funder's tokens.
     function test_register_RevertWhen_unauthorizedCaller() public {
         vm.expectRevert(ComposableCowPoller.UnauthorizedCaller.selector);
@@ -192,7 +227,9 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         bytes32 id = poller.scheduleId(schedule);
 
         vm.expectEmit(true, true, true, true, address(poller));
-        emit ScheduleRegistered(id, address(safe1), funder);
+        emit ScheduleRegistered(
+            id, address(safe1), funder, IConditionalOrderGenerator(address(twap)), SALT, keccak256(schedule.staticInput)
+        );
         vm.prank(address(safe1));
         poller.register(schedule);
         (IConditionalOrderGenerator handler,,,,) = poller.schedules(id);


### PR DESCRIPTION
Addresses https://github.com/cowprotocol/composable-cow/pull/123#discussion_r3600738703. I would personally close this PR unmerged and merge this other one https://github.com/cowprotocol/composable-cow/pull/130

Adds the fields that `id` commits to:

```solidity
event ScheduleRegistered(
    bytes32 indexed id,
    address indexed owner,
    address indexed funder,
    IConditionalOrderGenerator handler, // new
    bytes32 salt,                       // new
    bytes32 staticInputHash             // new
);
```

`staticInput` is hashed rather than emitted in full to keep it cheap, which was Igor's concern on the thread.

Gas: **`register` +1,422**, `pollFunds` unchanged.

## Test plan

```bash
forge test --match-path 'test/ComposableCowPoller.t.sol'   

# see the cost: compare the `register` row on the base and on this branch
git checkout feat/poller-ctx-hash              && forge test --gas-report --match-path 'test/ComposableCowPoller.t.sol'
git checkout feat/poller-register-event-fields && forge test --gas-report --match-path 'test/ComposableCowPoller.t.sol'
```

| | base | this PR | delta |
|---|---|---|---|
| `register` median | 303,215 | 304,637 | **+1,422** |
| `pollFunds` median | 122,132 | 122,132 | **0** |
