### PR TITLE
perf(poller): derive the order key locally

### DIFF
--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -106,6 +106,24 @@ contract ComposableCowPoller {
         delete schedules[id];
     }
 
+    /// @notice Derives the ComposableCoW order key a schedule funds.
+    /// @dev Mirrors `ComposableCoW.hash(params)` rather than calling it: the value is identical,
+    ///      and deriving it here avoids re-encoding `staticInput` as calldata for an external
+    ///      call. The equivalence is exercised by the `pollFunds` tests, which revert
+    ///      `OrderNotLive` if the derived key does not match the authorised order.
+    /// @return The order key, as used by `singleOrders`, `cabinet`, and `remove`.
+    function _ctx(IConditionalOrderGenerator handler, bytes32 salt, bytes memory staticInput)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encode(
+                IConditionalOrder.ConditionalOrderParams({handler: handler, salt: salt, staticInput: staticInput})
+            )
+        );
+    }
+
     /// @notice Move the current order's `sellAmount` from the funder to the owner. Permissionless.
     ///         The full amount always moves (no balance check), so one owner can serve several
     ///         concurrent orders.
@@ -114,11 +132,7 @@ contract ComposableCowPoller {
         if (schedule.funder == address(0)) revert NoSchedule();
 
         // Re-derive `ctx` on-chain, so `pollFunds(id)` stays independent of the order's `appData`.
-        bytes32 ctx = COMPOSABLE_COW.hash(
-            IConditionalOrder.ConditionalOrderParams({
-                handler: schedule.handler, salt: schedule.salt, staticInput: schedule.staticInput
-            })
-        );
+        bytes32 ctx = _ctx(schedule.handler, schedule.salt, schedule.staticInput);
 
         // The order must still be authorised; `remove` disables the poller.
         if (!COMPOSABLE_COW.singleOrders(schedule.owner, ctx)) revert OrderNotLive();

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -87,7 +87,7 @@ contract ComposableCowPoller {
     ///      Only the funds source may register, and the ID is namespaced by the funder. Funding
     ///      history is preserved across updates; use a new salt for a new logical schedule.
     ///      A zero `owner` or `handler` needs no check: `pollFunds` requires
-    ///      `singleOrders[owner][ctx]`, which neither can ever satisfy.
+    ///      `singleOrders[owner][paramsHash]`, which neither can ever satisfy.
     /// @param schedule The schedule to store.
     /// @return id The deterministic key of the stored schedule.
     function register(Schedule calldata schedule) external returns (bytes32 id) {
@@ -106,13 +106,15 @@ contract ComposableCowPoller {
         delete schedules[id];
     }
 
-    /// @notice Derives the ComposableCoW order key a schedule funds.
+    /// @notice Hashes a schedule's `ConditionalOrderParams`, which is the order key it funds.
     /// @dev Mirrors `ComposableCoW.hash(params)` rather than calling it: the value is identical,
     ///      and deriving it here avoids re-encoding `staticInput` as calldata for an external
     ///      call. The equivalence is exercised by the `pollFunds` tests, which revert
     ///      `OrderNotLive` if the derived key does not match the authorised order.
-    /// @return The order key, as used by `singleOrders`, `cabinet`, and `remove`.
-    function _ctx(IConditionalOrderGenerator handler, bytes32 salt, bytes memory staticInput)
+    /// @return The params hash. `ComposableCoW` calls this the order's `ctx`, though only for
+    ///         single orders: under a merkle root its `ctx` is zero. The poller only funds single
+    ///         orders, so the two always coincide here.
+    function _paramsHash(IConditionalOrderGenerator handler, bytes32 salt, bytes memory staticInput)
         internal
         pure
         returns (bytes32)
@@ -131,15 +133,15 @@ contract ComposableCowPoller {
         Schedule memory schedule = schedules[id];
         if (schedule.funder == address(0)) revert NoSchedule();
 
-        // Re-derive `ctx` on-chain, so `pollFunds(id)` stays independent of the order's `appData`.
-        bytes32 ctx = _ctx(schedule.handler, schedule.salt, schedule.staticInput);
+        // Re-derive the hash on-chain, so `pollFunds(id)` stays independent of the order's `appData`.
+        bytes32 paramsHash = _paramsHash(schedule.handler, schedule.salt, schedule.staticInput);
 
         // The order must still be authorised; `remove` disables the poller.
-        if (!COMPOSABLE_COW.singleOrders(schedule.owner, ctx)) revert OrderNotLive();
+        if (!COMPOSABLE_COW.singleOrders(schedule.owner, paramsHash)) revert OrderNotLive();
 
         // The handler yields the current order and reverts outside its window.
-        GPv2Order.Data memory order =
-            schedule.handler.getTradeableOrder(schedule.owner, address(this), ctx, schedule.staticInput, bytes(""));
+        GPv2Order.Data memory order = schedule.handler
+            .getTradeableOrder(schedule.owner, address(this), paramsHash, schedule.staticInput, bytes(""));
 
         // `ComposableCoW` exposes the settlement domain separator it received at deployment.
         bytes32 digest = GPv2Order.hash(order, COMPOSABLE_COW.domainSeparator());

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -36,7 +36,7 @@ contract ComposableCowPoller {
     /// @dev Keyed by `id == scheduleId(schedule)`, which excludes the order's `appData`.
     mapping(bytes32 => Schedule) public schedules;
 
-    /// @dev `id => digest => funded`. History survives schedule updates so an old order cannot be replayed.
+    /// @dev `id => orderDigest => funded`. History survives schedule updates so an old order cannot be replayed.
     mapping(bytes32 => mapping(bytes32 => bool)) public funded;
 
     /// @notice Thrown when someone other than the schedule funder registers, updates, or revokes a schedule.
@@ -144,11 +144,11 @@ contract ComposableCowPoller {
             .getTradeableOrder(schedule.owner, address(this), paramsHash, schedule.staticInput, bytes(""));
 
         // `ComposableCoW` exposes the settlement domain separator it received at deployment.
-        bytes32 digest = GPv2Order.hash(order, COMPOSABLE_COW.domainSeparator());
-        if (funded[id][digest]) return;
-        funded[id][digest] = true;
+        bytes32 orderDigest = GPv2Order.hash(order, COMPOSABLE_COW.domainSeparator());
+        if (funded[id][orderDigest]) return;
+        funded[id][orderDigest] = true;
 
         order.sellToken.safeTransferFrom(schedule.funder, schedule.owner, order.sellAmount);
-        emit Pulled(id, digest, order.sellAmount);
+        emit Pulled(id, orderDigest, order.sellAmount);
     }
 }


### PR DESCRIPTION
Applies a small gas improvement on the way we get the `ctx` on the polling. Polling is done multiple times, so any cost saving is appreciated :) 

## NOTE: Regarding approvals
This PR lost the approvals when rebasing to main after squashing the dependant PR. 
It had one approval from Igor, and a nitpick from Kaze. I will merge, because 2 PRs depend on this and I would like to consolidate these PRs asap. It is a minor change. 

```
21:06:02  review_dismissed        reason: "The base branch was changed."   was: approved
```


## Context
`pollFunds` got `ctx` by calling `ComposableCoW.hash(params)`. That is an external call whose arguments must be ABI-encoded as calldata, and `staticInput` is dynamic, so the encoding dominates the cost.

`ComposableCoW.hash` is `public pure` and just returns `keccak256(abi.encode(params))`, so this mirrors it in a `_ctx` helper. The value is identical — only the call is avoided. If it ever diverged, `pollFunds` would stop finding the order in `singleOrders` and revert `OrderNotLive`, so every polling test already checks the equivalence.

| | before | after | delta |
|---|---|---|---|
| `pollFunds` | 124,640 | 122,132 | **−2,508** |
| bytecode size | 6,147 | 6,047 | **−100 bytes** |

`register` is untouched. Cheaper and smaller, so worth doing on its own. Split out of #130 so the event-field choice there can be judged on its own cost.

## Test plan

```bash
forge test --match-path 'test/ComposableCowPoller.t.sol'

# see the saving: snapshot the base, then diff this branch against it
git checkout feat/poller-deploy   && forge snapshot --snap /tmp/base.gas --match-path 'test/ComposableCowPoller.t.sol'
git checkout feat/poller-ctx-hash && forge snapshot --diff /tmp/base.gas --match-path 'test/ComposableCowPoller.t.sol'
```

It decreases gas for 7 of the 8 tests that poll funds — `RevertWhen_noSchedule` is flat because it reverts before the changed line. Everything that does not poll is flat too, which is what shows `register` is untouched.

<img width="1035" height="411" alt="image" src="https://github.com/user-attachments/assets/d85cc5f2-79eb-44c5-a545-9347b3c4dfbb" />

