### PR TITLE
feat(poller): reject registering a taken key

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For the purposes of outlining the methodologies, it is assumed that:
 A conditional order is a struct `ConditionalOrderParams`, consisting of:
 
 1. The address of handler, ie. type of conditional order (such as `TWAP`).
-2. A unique salt.
+2. A unique `salt` - a fresh random value per order, as it is what keeps two otherwise-identical orders distinct.
 3. Implementation specific `staticInput` - data that is known at the creation time of the conditional order.
 
 ##### Single Order
@@ -103,8 +103,8 @@ To create a TWAP order:
 
 1. ABI-Encode the `IConditionalOrder.ConditionalOrderParams` struct with:
    - `handler`: set to the `TWAP` smart contract deployment.
-   - `salt`: use a value unique to the user and logical order. For poller schedules, a good default is
-     the hash of the order-defining `staticInput` values with any `appData` field set to zero.
+   - `salt`: a fresh random value per order. It is what keeps two otherwise-identical orders distinct,
+     so reusing one makes them indistinguishable.
    - `staticInput`: the ABI-encoded `TWAP.Data` struct.
 2. Use the `struct` from (1) as either a Merkle leaf, or with `ComposableCoW.create` to create a single conditional order.
 3. Approve `GPv2VaultRelayer` to trade `n x partSellAmount` of the safe's `sellToken` tokens (in the example above, `GPv2VaultRelayer` would receive approval for spending 12,000,000 DAI tokens).

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -15,7 +15,9 @@ contract ComposableCowPoller {
     ComposableCoW public immutable COMPOSABLE_COW;
 
     /// @notice Parameters for a JIT funding schedule.
-    /// @dev A schedule is uniquely identified by its funder, handler, owner, and salt.
+    /// @dev `handler`, `salt` and `staticInput` are the order's `ConditionalOrderParams` and must
+    ///      match it exactly, since `paramsHash` is derived from them. The schedule key is `funder`,
+    ///      `handler`, `owner`, and `salt`.
     struct Schedule {
         /// @notice The conditional-order handler to poll, such as the TWAP type.
         IConditionalOrderGenerator handler;
@@ -25,11 +27,12 @@ contract ComposableCowPoller {
         /// @notice The address that owns the ComposableCoW conditional order and receives the pulled funds.
         /// @dev It can be an EOA or contract and may be the same address as `funder`.
         address owner;
-        /// @notice A user-controlled namespace for this schedule.
-        /// @dev Keep it unique to the user and logical order. A good default is the hash of the
-        ///      order-defining static-input values with any appData field set to zero.
+        /// @notice The conditional order's own `salt`.
+        /// @dev It is what keeps two otherwise-identical orders distinct in ComposableCoW, so use
+        ///      a fresh random value per order.
         bytes32 salt;
-        /// @notice The static input passed to the handler when it generates an order.
+        /// @notice The order's `staticInput`, byte-for-byte.
+        /// @dev A mismatch is not caught at registration; `pollFunds` reverts `OrderNotLive`.
         bytes staticInput;
     }
 
@@ -77,9 +80,8 @@ contract ComposableCowPoller {
     event ScheduleRevoked(bytes32 indexed id, address indexed owner, address indexed funder);
 
     /// @notice Computes the deterministic, appData-independent schedule key.
-    /// @dev `staticInput` is excluded because its appData can depend on this key.
-    ///      Keep the salt unique to the user and logical order. A good default is the hash of the
-    ///      order-defining static-input values with any appData field set to zero.
+    /// @dev `staticInput` is excluded because its appData can depend on this key, which is why a
+    ///      fresh `salt` per order is what keeps distinct orders on distinct keys.
     /// @param schedule The schedule whose identity fields determine the key.
     /// @return The schedule key.
     function scheduleId(Schedule memory schedule) public pure returns (bytes32) {

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -42,6 +42,10 @@ contract ComposableCowPoller {
     /// @notice Thrown when someone other than the schedule funder registers, updates, or revokes a schedule.
     error OnlyFunder();
 
+    /// @notice Thrown when registering a schedule whose key is already taken. Revoke it first to
+    ///         replace it deliberately.
+    error AlreadyRegistered();
+
     /// @notice Thrown when polling an ID that has no registered schedule, because it was never
     ///         registered or has since been revoked.
     error NoSchedule();
@@ -82,10 +86,12 @@ contract ComposableCowPoller {
         return keccak256(abi.encode(schedule.funder, schedule.handler, schedule.owner, schedule.salt));
     }
 
-    /// @notice Registers or updates a schedule.
-    /// @dev Registering the same funder, handler, owner, and salt replaces the stored schedule.
-    ///      Only the funds source may register, and the ID is namespaced by the funder. Funding
-    ///      history is preserved across updates; use a new salt for a new logical schedule.
+    /// @notice Registers a schedule.
+    /// @dev Reverts if the key is taken. The key ignores `staticInput`, so silently overwriting
+    ///      would leave the previous — still authorised — order unfundable with nothing in the
+    ///      logs to show it. `revoke` first to replace a schedule deliberately; funding history
+    ///      survives that, so an old order cannot be replayed.
+    ///      Only the funds source may register, and the ID is namespaced by the funder.
     ///      A zero `owner` or `handler` needs no check: `pollFunds` requires
     ///      `singleOrders[owner][paramsHash]`, which neither can ever satisfy.
     /// @param schedule The schedule to store.
@@ -93,6 +99,7 @@ contract ComposableCowPoller {
     function register(Schedule calldata schedule) external returns (bytes32 id) {
         if (msg.sender != schedule.funder) revert OnlyFunder();
         id = scheduleId(schedule);
+        if (schedules[id].funder != address(0)) revert AlreadyRegistered();
         schedules[id] = schedule;
         emit ScheduleRegistered(id, schedule.owner, schedule.funder);
     }

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -143,17 +143,33 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         assertEq(secondSalt, SECOND_SALT, "second schedule stored");
     }
 
-    /// @dev Registering the same key updates the one schedule stored under that id.
-    function test_register_replacesScheduleWithSameId() public {
-        bytes32 id = _register(_schedule(SALT, abi.encode(_bundle())));
-        TWAPOrder.Data memory replacement = _bundle();
-        replacement.appData = keccak256("updated dca pull");
-        bytes memory updatedStaticInput = abi.encode(replacement);
+    /// @dev A taken key is rejected, even for a different order, so a live order is never orphaned.
+    function test_register_RevertWhen_alreadyRegistered() public {
+        _register(_schedule(SALT, abi.encode(_bundle())));
 
-        assertEq(_register(_schedule(SALT, updatedStaticInput)), id, "same key keeps same id");
+        TWAPOrder.Data memory other = _bundle();
+        other.partSellAmount = TWAP_PART_AMOUNT * 2;
 
-        (,,,, bytes memory staticInput) = poller.schedules(id);
-        assertEq(staticInput, updatedStaticInput, "replacement input stored");
+        vm.prank(funder);
+        vm.expectRevert(ComposableCowPoller.AlreadyRegistered.selector);
+        poller.register(_schedule(SALT, abi.encode(other)));
+    }
+
+    /// @dev Revoking frees the key, so a schedule can still be replaced deliberately.
+    function test_register_afterRevokeReusesTheKey() public {
+        bytes memory staticInput = abi.encode(_bundle());
+        bytes32 id = _register(_schedule(SALT, staticInput));
+
+        vm.prank(funder);
+        poller.revoke(id);
+
+        TWAPOrder.Data memory other = _bundle();
+        other.partSellAmount = TWAP_PART_AMOUNT * 2;
+        bytes memory updated = abi.encode(other);
+        assertEq(_register(_schedule(SALT, updated)), id, "same key reused");
+
+        (,,,, bytes memory stored) = poller.schedules(id);
+        assertEq(stored, updated, "replacement input stored");
     }
 
     /// @dev Only the funds source may register a schedule that draws on its own funds.
@@ -261,6 +277,9 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         poller.pollFunds(id);
         vm.prank(address(safe1));
         assertTrue(token0.transfer(bob.addr, TWAP_PART_AMOUNT), "second order settled");
+
+        vm.prank(funder);
+        poller.revoke(id);
 
         vm.prank(funder);
         assertEq(


### PR DESCRIPTION
Follow up to #125, addressing https://github.com/cowprotocol/composable-cow/pull/125#discussion_r3578723006 — Igor's suggestion to reject overriding existing IDs.

The schedule key ignores `staticInput`, so registering over an existing key replaced the stored schedule and left the previous, still authorised, order unfundable. Nothing in the logs showed it: that `ScheduleRegistered` looked like any other.

Now it reverts with `AlreadyRegistered`. To replace a schedule deliberately, `revoke` first — that emits `ScheduleRevoked` and can be batched with the new `register` in one transaction. `funded[id][digest]` is not cleared by `revoke`, so replay protection survives the cycle.

Gas: **`register` +201** (0.07%), +95 bytes. Nearly free, since `register` already writes that slot.

Also rewrites the `salt` natspec, which called it "a user-controlled namespace" and recommended deriving it from the static input with appData zeroed. It is really the conditional order's own `salt` — the same value ComposableCoW hashes into `ctx` — so that derivation would give two identical orders the same key and stop them coexisting, and the contract can never verify it anyway. It now states the constraint and recommends a fresh random value per order. Discussion: https://github.com/cowprotocol/composable-cow/pull/125#issuecomment-5123134104


## Test plan

```bash
forge test --match-path 'test/ComposableCowPoller.t.sol'   # 24 passed
```

`test_register_replacesScheduleWithSameId` becomes `test_register_RevertWhen_alreadyRegistered`, plus `test_register_afterRevokeReusesTheKey` for the deliberate-replacement path.


## NOTE: Approvals

Again, it just removed Igors approval when I merged the dependant PR

<img width="1073" height="82" alt="image" src="https://github.com/user-attachments/assets/3483743b-c846-4453-a6eb-bda04255eb7e" />
