### PR TITLE
feat(poller): finalise the pollFunds observable surface

### DIFF
--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -67,11 +67,14 @@ contract ComposableCowPoller {
     ///        which is what makes such a replacement visible off-chain.
     event ScheduleRegistered(bytes32 indexed id, address indexed owner, address indexed funder, bytes32 paramsHash);
 
-    /// @notice Emitted when an order's sell amount is moved from the funder to the owner.
-    /// @param id The deterministic key of the schedule that was polled.
-    /// @param orderDigest The EIP-712 digest of the funded order, unique per part of the schedule.
-    /// @param amount The amount of `sellToken` transferred.
-    event Pulled(bytes32 indexed id, bytes32 orderDigest, uint256 amount);
+    /// @notice Emitted when a part's funds are moved.
+    /// @dev `orderDigest` is indexed so a single leg can be looked up directly, rather than only
+    ///      by walking a schedule's history. It is the CoW order struct hash, so it joins to
+    ///      settlement data.
+    /// @param id The deterministic key of the schedule.
+    /// @param orderDigest The digest of the order that was funded.
+    /// @param amount The `sellAmount` moved from the funder to the owner.
+    event Pulled(bytes32 indexed id, bytes32 indexed orderDigest, uint256 amount);
 
     constructor(ComposableCoW _composableCow) {
         COMPOSABLE_COW = _composableCow;

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -144,7 +144,10 @@ contract ComposableCowPoller {
     /// @notice Move the current order's `sellAmount` from the funder to the owner. Permissionless.
     ///         The full amount always moves (no balance check), so one owner can serve several
     ///         concurrent orders.
-    function pollFunds(bytes32 id) external {
+    /// @return Whether funds moved. `false` means this order was already funded, which is the one
+    ///         outcome a caller cannot otherwise tell apart from a transfer without diffing
+    ///         balances; every other case reverts.
+    function pollFunds(bytes32 id) external returns (bool) {
         Schedule memory schedule = schedules[id];
         if (schedule.funder == address(0)) revert NoSchedule();
 
@@ -160,10 +163,11 @@ contract ComposableCowPoller {
 
         // `ComposableCoW` exposes the settlement domain separator it received at deployment.
         bytes32 orderDigest = GPv2Order.hash(order, COMPOSABLE_COW.domainSeparator());
-        if (funded[id][orderDigest]) return;
+        if (funded[id][orderDigest]) return false;
         funded[id][orderDigest] = true;
 
         order.sellToken.safeTransferFrom(schedule.funder, schedule.owner, order.sellAmount);
         emit Pulled(id, orderDigest, order.sellAmount);
+        return true;
     }
 }

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -272,7 +272,7 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         // The owner already holds an unrelated balance (e.g. funded for another order).
         deal(address(token0), address(safe1), TWAP_PART_AMOUNT);
 
-        poller.pollFunds(id);
+        assertTrue(poller.pollFunds(id), "funds moved");
 
         assertEq(
             token0.balanceOf(address(safe1)), TWAP_PART_AMOUNT * 2, "full part pulled on top of the existing balance"
@@ -285,13 +285,13 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         (, bytes32 paramsHash, bytes32 id) = _setupSchedule();
         vm.warp(_t0(paramsHash));
 
-        poller.pollFunds(id);
+        assertTrue(poller.pollFunds(id), "funds moved");
 
         vm.prank(address(safe1));
         assertTrue(token0.transfer(bob.addr, TWAP_PART_AMOUNT), "part settled");
         assertEq(token0.balanceOf(address(safe1)), 0, "part settled");
 
-        poller.pollFunds(id); // no-op: this part has already been funded
+        assertFalse(poller.pollFunds(id), "already funded, no-op");
 
         assertEq(token0.balanceOf(address(safe1)), 0, "next part not funded early");
         assertEq(token0.balanceOf(funder), TWAP_PART_AMOUNT * N - TWAP_PART_AMOUNT, "no extra pull");
@@ -313,13 +313,13 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         orderB.appData = keccak256("second valid order");
 
         vm.mockCall(address(twap), handlerCall, abi.encode(orderA));
-        poller.pollFunds(id);
+        assertTrue(poller.pollFunds(id), "first order funded");
         vm.prank(address(safe1));
         assertTrue(token0.transfer(bob.addr, TWAP_PART_AMOUNT), "first order settled");
 
         vm.clearMockedCalls();
         vm.mockCall(address(twap), handlerCall, abi.encode(orderB));
-        poller.pollFunds(id);
+        assertTrue(poller.pollFunds(id), "second order funded");
         vm.prank(address(safe1));
         assertTrue(token0.transfer(bob.addr, TWAP_PART_AMOUNT), "second order settled");
 
@@ -343,7 +343,7 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
 
         vm.clearMockedCalls();
         vm.mockCall(address(twap), handlerCall, abi.encode(orderA));
-        poller.pollFunds(id);
+        assertFalse(poller.pollFunds(id), "first order already funded, no-op");
 
         assertEq(token0.balanceOf(address(safe1)), 0, "first order not funded twice");
         assertEq(token0.balanceOf(funder), TWAP_PART_AMOUNT, "only two distinct orders funded");
@@ -375,7 +375,7 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
             vm.warp(t0 + part * FREQ);
 
             assertEq(token0.balanceOf(address(safe1)), 0, "owner empty before part");
-            poller.pollFunds(id);
+            assertTrue(poller.pollFunds(id), "funds moved for this part");
             assertEq(token0.balanceOf(address(safe1)), TWAP_PART_AMOUNT, "part funded");
 
             // Simulate the part settling: the owner's balance is consumed.

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -28,6 +28,7 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
 
     event ScheduleRegistered(bytes32 indexed id, address indexed owner, address indexed funder, bytes32 paramsHash);
     event ScheduleRevoked(bytes32 indexed id, address indexed owner, address indexed funder);
+    event Pulled(bytes32 indexed id, bytes32 indexed orderDigest, uint256 amount);
 
     function setUp() public virtual override(BaseComposableCoWTest) {
         super.setUp();
@@ -271,6 +272,11 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
 
         // The owner already holds an unrelated balance (e.g. funded for another order).
         deal(address(token0), address(safe1), TWAP_PART_AMOUNT);
+
+        GPv2Order.Data memory order =
+            twap.getTradeableOrder(address(safe1), address(poller), ctx, abi.encode(_bundle()), bytes(""));
+        vm.expectEmit(true, true, true, true, address(poller));
+        emit Pulled(id, GPv2Order.hash(order, composableCow.domainSeparator()), order.sellAmount);
 
         assertTrue(poller.pollFunds(id), "funds moved");
 


### PR DESCRIPTION
Follow up to #125, addressing https://github.com/cowprotocol/composable-cow/pull/125#discussion_r3601055050 

`pollFunds` has two successful outcomes: funds moved, or this order was already funded and nothing happened. 

An on-chain caller cannot tell them apart without diffing balances before and after. 

Every other case reverts, so a bool says it exactly.

I was in the fence with doing or not doing, because we don't need it right now (for TWAP for EOAs, since this is a direct call in the hooks), but:
- It adds just 77 gas units, insignificant
- Allows future use cases where we wrap this contract to do some action after the funds have been moved. 


| | before | after | delta |
|---|---|---|---|
| `pollFunds` median | 122,132 | 122,209 | **+77** |
| bytecode | 6,047 | 6,060 | +13 bytes |

`register` is unaffected.

## Also: index `orderDigest` on `Pulled`

Addressing https://github.com/cowprotocol/composable-cow/pull/125#discussion_r3681587079 — same reasoning as above, an ABI decision that can only be made before deployment.

Only `id` was indexed, so every query had to start from the schedule. `orderDigest` is the CoW order struct hash, so indexing it lets a single leg be looked up directly and joined to settlement data. `indexed` does not change the event signature, so a consumer built against the old layout would silently misdecode rather than fail.

| | before | after | delta |
|---|---|---|---|
| `pollFunds` median | 122,209 | 122,307 | **+98** |
| bytecode | 6,060 | 6,052 | **−8 bytes** |

Smaller, because the value moves out of the ABI-encoded data.

`Pulled` had no test at all, so its layout was unverified. `test_pollFunds_movesFullAmountUnconditionally` now asserts it — I checked the assertion fails on both a wrong digest and a wrong amount.

Combined effect of both commits versus #131: `pollFunds` 122,132 → 122,307 (+175), bytecode 6,047 → 6,052 (+5).


## Test plan

```bash
forge test --match-path 'test/ComposableCowPoller.t.sol'  
```



## NOTE: Approvals

This is annoying, not sure which setting is doing this, but  every time I merge a dependant PR I loose the approvals without changing any code in the branch.  


<img width="1189" height="563" alt="image" src="https://github.com/user-attachments/assets/92d441ea-ef15-4202-9b09-b24ccebabf3a" />
