### PR TITLE
feat: generate networks.json from the deployment artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,24 @@ COMPOSABLE_COW=0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74 \
 The `broadcast` directory collects the latest run of the deployment script by network and is updated manually.
 When the script is ran, the corresponding files can be found in the folder `broadcast/deploy_OrderTypes.s.sol/`.
 
+#### Updating `networks.json`
+
+[`networks.json`](./networks.json) lists the address and creation transaction of every deployed
+contract by chain id. It is generated, not edited by hand. After deploying, regenerate it with:
+
+```bash
+bash dev/generate-networks-file.sh > networks.json
+```
+
+The script reads the deployment artifacts in `broadcast/`. Re-running it on an unchanged repository
+must leave the file untouched, so `git diff --exit-code networks.json` is a quick way to check that
+the committed file is in sync with the artifacts.
+
+Some chains can't be deployed to with the scripts (see
+[#93](https://github.com/cowprotocol/composable-cow/issues/93)) and are deployed by hand, leaving no
+artifact behind. Record those in [`broadcast/networks-manual.json`](./broadcast/networks-manual.json),
+which has the same shape as `networks.json` and is merged on top of the generated result.
+
 #### Contract verification on block explorer
 
 There's a dedicated script to verify all contracts at the same time once they have been deployed on a new chain:

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Because of the issue [#39](https://github.com/cowprotocol/composable-cow/issues/
 
 ### Script-based deployment
 
-⚠ This approach won't deploy the contracts to the official addresses.
+⚠️ This approach won't deploy the contracts to the official addresses.
 It's mainly useful for testing or when introducing a new contract type.
 
 Deployment is handled by solidity scripts in `forge`. The network being deployed to is dependent on the `ETH_RPC_URL`.
@@ -218,21 +218,25 @@ When the script is ran, the corresponding files can be found in the folder `broa
 
 #### Updating `networks.json`
 
-[`networks.json`](./networks.json) lists the address and creation transaction of every deployed
-contract by chain id. It is generated, not edited by hand. After deploying, regenerate it with:
+[`networks.json`](./networks.json) lists the address and creation transaction of the latest official deployments by chain. 
+
+It is generated automatically. After deploying, regenerate it with:
 
 ```bash
 bash dev/generate-networks-file.sh > networks.json
 ```
 
-The script reads the deployment artifacts in `broadcast/`. Re-running it on an unchanged repository
-must leave the file untouched, so `git diff --exit-code networks.json` is a quick way to check that
-the committed file is in sync with the artifacts.
-
-Some chains can't be deployed to with the scripts (see
+The script figures out the official contract address from 2 sources:
+- `broadcast/**/*.json`: Reads the Foundry deployment artifacts. 
+- `broadcast/networks-manual.json`: Some chains can't be deployed to with the scripts (see
 [#93](https://github.com/cowprotocol/composable-cow/issues/93)) and are deployed by hand, leaving no
 artifact behind. Record those in [`broadcast/networks-manual.json`](./broadcast/networks-manual.json),
 which has the same shape as `networks.json` and is merged on top of the generated result.
+
+Re-running the script on an unchanged repository must leave the file untouched, so a quick way to check there´s no drift is to run:
+```bash
+bash dev/generate-networks-file.sh > networks.json && git diff --exit-code networks.json
+```
 
 #### Contract verification on block explorer
 

--- a/README.md
+++ b/README.md
@@ -233,9 +233,9 @@ The script figures out the official contract address from 2 sources:
 artifact behind. Record those in [`broadcast/networks-manual.json`](./broadcast/networks-manual.json),
 which has the same shape as `networks.json` and is merged on top of the generated result.
 
-Re-running the script on an unchanged repository must leave the file untouched, so a quick way to check there´s no drift is to run:
+Re-running the script on an unchanged repository must reproduce the committed file, so a quick way to check there´s no drift is to run:
 ```bash
-bash dev/generate-networks-file.sh > networks.json && git diff --exit-code networks.json
+diff -u networks.json <(bash dev/generate-networks-file.sh)
 ```
 
 #### Contract verification on block explorer

--- a/broadcast/networks-manual.json
+++ b/broadcast/networks-manual.json
@@ -1,5 +1,9 @@
 {
   "ComposableCoW": {
+    "1": {
+      "address": "0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74",
+      "transactionHash": "0x2d4159ae0d4f026e2063292f3e40d898982619853484b8cd84f3748503fcdd19"
+    },
     "232": {
       "address": "0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74",
       "transactionHash": "0x39105403b3b7ee84959807135fbebb1bba1de86f85916295d99ff69617c15ae0"
@@ -36,6 +40,10 @@
     }
   },
   "ExtensibleFallbackHandler": {
+    "1": {
+      "address": "0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5",
+      "transactionHash": "0x33dcbc73a8797c69a5b3956539dd8d191cf3f190bcb27a4d4eca8556f030f574"
+    },
     "232": {
       "address": "0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5",
       "transactionHash": "0xe912dc9c8ca00fd9bb06805d466e60fcd126f8bcaa699c257af94d26c158fe48"

--- a/broadcast/networks-manual.json
+++ b/broadcast/networks-manual.json
@@ -1,0 +1,146 @@
+{
+  "ComposableCoW": {
+    "232": {
+      "address": "0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74",
+      "transactionHash": "0x39105403b3b7ee84959807135fbebb1bba1de86f85916295d99ff69617c15ae0"
+    },
+    "56": {
+      "address": "0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74",
+      "transactionHash": "0x6595bc3c236157c5a164eb37267486b3c2f6eee02d2e6d9068550e939b18ed71"
+    },
+    "59144": {
+      "address": "0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74",
+      "transactionHash": "0x61f2e7ecec07f7b5c93d491f460cca41eba991fbb022f6866ee17510c9e61151"
+    },
+    "9745": {
+      "address": "0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74",
+      "transactionHash": "0xa4db8e5f949f39af60460fc05979b363b01570970e94eb8397dc39cfbdcaed86"
+    }
+  },
+  "CurrentBlockTimestampFactory": {
+    "232": {
+      "address": "0x52eD56Da04309Aca4c3FECC595298d80C2f16BAc",
+      "transactionHash": "0x89f445ba1d7fa8db82eb0a84ed58d579d6d67498d3bd83f95bac3cbaaf72c7c7"
+    },
+    "56": {
+      "address": "0x52eD56Da04309Aca4c3FECC595298d80C2f16BAc",
+      "transactionHash": "0x39ee6b5a04b966012413cfcfbcfe4d95c9e0ef3b6e2bd3943d831cc63c3e7332"
+    },
+    "59144": {
+      "address": "0x52eD56Da04309Aca4c3FECC595298d80C2f16BAc",
+      "transactionHash": "0x089c5e35c63d3bd817767643f2194e2afc28b91aca7c9b2936002b1ee5ce707b"
+    },
+    "9745": {
+      "address": "0x52eD56Da04309Aca4c3FECC595298d80C2f16BAc",
+      "transactionHash": "0x46f9e4e27cd6a7ad779aa588f33e62a497e64a2317496d6e85f218c551d68b71"
+    }
+  },
+  "ExtensibleFallbackHandler": {
+    "232": {
+      "address": "0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5",
+      "transactionHash": "0xe912dc9c8ca00fd9bb06805d466e60fcd126f8bcaa699c257af94d26c158fe48"
+    },
+    "56": {
+      "address": "0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5",
+      "transactionHash": "0x7925843f63a475036777068141b6e63aae6e31970c62f553cfaacd03391965f2"
+    },
+    "59144": {
+      "address": "0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5",
+      "transactionHash": "0x2bc6a058c5658ca21334490b02d9f77dfc987bff8e5380bba4313fa99488a7c7"
+    },
+    "9745": {
+      "address": "0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5",
+      "transactionHash": "0xb5cf37e866a932e7cd95c760766223b1dcfb407fce294062d669db200e543604"
+    }
+  },
+  "GoodAfterTime": {
+    "232": {
+      "address": "0xdaf33924925e03c9cc3a10d434016d6cfad0add5",
+      "transactionHash": "0x47fd8b353a367f12a6c1342ae031bba0a88be193e3d0efedfbe81b2575cc27d7"
+    },
+    "56": {
+      "address": "0xdaf33924925e03c9cc3a10d434016d6cfad0add5",
+      "transactionHash": "0x9804d039774d81cc7d67e5a18b5b12d4bf146fa88a7f87f5e6c0b66fdd2f9b4f"
+    },
+    "59144": {
+      "address": "0xdaf33924925e03c9cc3a10d434016d6cfad0add5",
+      "transactionHash": "0x754fd8491a7169e88a92dd08bf74eabba9b23ac58399a13f291de59ba3d706a7"
+    },
+    "9745": {
+      "address": "0xdaf33924925e03c9cc3a10d434016d6cfad0add5",
+      "transactionHash": "0x43ecdd69293799034f379b6a4c8b78c3f9cb16b6b66e60ca37049c2a815c74de"
+    }
+  },
+  "PerpetualStableSwap": {
+    "232": {
+      "address": "0x519BA24e959E33b3B6220CA98bd353d8c2D89920",
+      "transactionHash": "0x0ca48f39d980e2e5e2f198c2f2b02507cd02c41a6e95ff2e02118f07f2fc66ca"
+    },
+    "56": {
+      "address": "0x519BA24e959E33b3B6220CA98bd353d8c2D89920",
+      "transactionHash": "0xbbaff8f665fbd0f5fbaac6e50e4b5e9e13cb903a931e44546afcda43b2115544"
+    },
+    "59144": {
+      "address": "0x519BA24e959E33b3B6220CA98bd353d8c2D89920",
+      "transactionHash": "0x6634ffd9ca5e8825651fdce77e16529dda3c4fa1f26040bebc12ea5ed67b2176"
+    },
+    "9745": {
+      "address": "0x519BA24e959E33b3B6220CA98bd353d8c2D89920",
+      "transactionHash": "0x3057d442d99d8712f7141b50137ec797ace161612c2a5a508f8c1e2c587e7ef5"
+    }
+  },
+  "StopLoss": {
+    "232": {
+      "address": "0x412c36e5011cd2517016d243a2dfb37f73a242e7",
+      "transactionHash": "0xcd3ef47e00be486b9aa1d62ea5b39e0ce1bad95a5ff5111943d04e6ecaa35b67"
+    },
+    "56": {
+      "address": "0x412c36e5011cd2517016d243a2dfb37f73a242e7",
+      "transactionHash": "0x5fb136a96ec82c1cd886774e18da08622b99851acbdb9b912251a5d0efdf901b"
+    },
+    "59144": {
+      "address": "0x412c36e5011cd2517016d243a2dfb37f73a242e7",
+      "transactionHash": "0x2f9c97b55d70754125215cf05f8f8c01364f73d901e1691b19e2353cc15e4af9"
+    },
+    "9745": {
+      "address": "0x412c36e5011cd2517016d243a2dfb37f73a242e7",
+      "transactionHash": "0x1d83e6c681a4bcbda7c53fdee2a894341bc96b1fd64ef2535040b6c004b975f1"
+    }
+  },
+  "TWAP": {
+    "232": {
+      "address": "0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5",
+      "transactionHash": "0xda19203f82d31db7f547db1faf71aff43ab1c569bea2acaf6f611df77a28900d"
+    },
+    "56": {
+      "address": "0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5",
+      "transactionHash": "0x62f8a706f0885126204bbb25a046fbe2a277a0946ee7c02786b2dffdd53f87c8"
+    },
+    "59144": {
+      "address": "0x6cf1e9ca41f7611def408122793c358a3d11e5a5",
+      "transactionHash": "0x120ac507b9973897669829e6865fc95db3dd7dac8e6ece826d8350f870f01882"
+    },
+    "9745": {
+      "address": "0x6cf1e9ca41f7611def408122793c358a3d11e5a5",
+      "transactionHash": "0x2c15c6ddd0959c74d8b35e0f3e3e20192f9ec9b1682ee879d3dfc505b7d572b4"
+    }
+  },
+  "TradeAboveThreshold": {
+    "232": {
+      "address": "0x812308712a6d1367f437e1c1e4af85c854e1e9f6",
+      "transactionHash": "0xcee6c945d598162e5aca2d5f65418a1de9762e0f27279ef821706e0ca09f4f69"
+    },
+    "56": {
+      "address": "0x812308712a6d1367f437e1c1e4af85c854e1e9f6",
+      "transactionHash": "0x8289b8c2a52d065315cdbb183db079b041a46d435300c0f748b3c9489c1b97e7"
+    },
+    "59144": {
+      "address": "0x812308712a6d1367f437e1c1e4af85c854e1e9f6",
+      "transactionHash": "0x31db5dfb77cc6805d202930415c4155f07366bfecadb1b8d9885d8fb4ac0cf41"
+    },
+    "9745": {
+      "address": "0x812308712a6d1367f437e1c1e4af85c854e1e9f6",
+      "transactionHash": "0x27ebdbc0bd4f57f29df3ac701e4ba746f5910c170024b92a20099d6162861f6a"
+    }
+  }
+}

--- a/dev/generate-networks-file.sh
+++ b/dev/generate-networks-file.sh
@@ -14,15 +14,18 @@ generated=$(for deployment in "$repo_root_dir/broadcast/"*"/"*"/"*".json"; do
   # Extract contract info per chain. `CREATE` is accepted alongside `CREATE2` because the
   # standalone `deploy_ComposableCowPoller.s.sol` omits the salt, so the existing Gnosis Chain
   # poller was deployed non-deterministically.
-  jq --arg chainId "$chain_id" '
-    .transactions[]
+  jq --compact-output --arg chainId "$chain_id" '
+    # Foundry recorded seconds in older runs and milliseconds in newer ones.
+    (.timestamp | if . > 100000000000 then . / 1000 else . end | floor) as $ran_at
+    | .transactions[]
     | select(.transactionType == "CREATE" or .transactionType == "CREATE2")
     | select(.hash != null)
-    | {(.contractName): {($chainId): {address: .contractAddress, transactionHash: .hash }}}
+    | [$ran_at, {(.contractName): {($chainId): {address: .contractAddress, transactionHash: .hash }}}]
   ' <"$deployment"
-  # When the same contract appears more than once, the last one wins: within a run, the latest
-  # deployment; across runs, the path that sorts last (so `run-latest.json` beats `run-<timestamp>.json`).
-done | jq --sort-keys --null-input 'reduce inputs as $item ({}; . *= $item)')
+  # When the same contract appears more than once the most recent run wins. Ordering by run
+  # timestamp keeps that true across scripts, whose file paths sort arbitrarily. `sort_by` is
+  # stable, so a run's own transactions stay in order and the later one wins.
+done | jq --sort-keys --slurp 'sort_by(.[0]) | map(.[1]) | reduce .[] as $item ({}; . *= $item)')
 
 # Merge with manual file if it exists
 if [[ -f "$manual_file" ]]; then

--- a/dev/generate-networks-file.sh
+++ b/dev/generate-networks-file.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -o errexit -o pipefail -o nounset
+
+repo_root_dir="$(git rev-parse --show-toplevel)"
+manual_file="$repo_root_dir/broadcast/networks-manual.json"
+
+# Some networks can't be deployed to with the deployment scripts (see
+# https://github.com/cowprotocol/composable-cow/issues/93), so they have no broadcast artifacts to
+# read from. Those are recorded by hand in `broadcast/networks-manual.json`, which has the same
+# shape as `networks.json` and is merged on top of whatever the broadcast files produce.
+
+# Build the JSON out of the broadcast deployment artifacts.
+generated=$(for deployment in "$repo_root_dir/broadcast/"*"/"*"/"*".json"; do
+  # The subfolder name is the chain id
+  chain_id=${deployment%/*}
+  chain_id=${chain_id##*/}
+
+  # First, every single deployment is formatted as if it had its own networks.json.
+  # `CREATE` is accepted alongside `CREATE2` because not every contract is deployed
+  # deterministically: `deploy_ComposableCowPoller.s.sol` takes a constructor argument and is
+  # deployed without a salt.
+  jq --arg chainId "$chain_id" '
+    .transactions[]
+    | select(.transactionType == "CREATE" or .transactionType == "CREATE2")
+    | select(.hash != null)
+    | {(.contractName): {($chainId): {address: .contractAddress, transactionHash: .hash }}}
+  ' <"$deployment"
+done \
+  | # Then, all these single-contract single-chain-id networks.jsons are merged. Note: in case the same contract is
+    # deployed twice in the same script run, the last deployed contract takes priority.
+    # If the same contract is deployed twice in different runs, the address in the file path that comes latest in
+    # alphabetical order takes priority. For example, a contract in `broadcast/Deployment10/*` is overwritten by
+    # one with the same name from `broadcast/Deployment2/*`. `run-latest.json` sorts after any `run-<timestamp>.json`,
+    # so the most recent run of a script wins.
+    jq --sort-keys --null-input 'reduce inputs as $item ({}; . *= $item)')
+
+# Merge the manually recorded deployments on top, if there are any.
+if [[ -f "$manual_file" ]]; then
+  if ! jq empty "$manual_file" 2>/dev/null; then
+    echo "Error: $manual_file is not valid JSON." >&2
+    exit 1
+  fi
+
+  jq --slurp --sort-keys 'reduce .[] as $item ({}; . *= $item)' \
+    <(printf '%s' "$generated") "$manual_file"
+else
+  printf '%s\n' "$generated"
+fi

--- a/dev/generate-networks-file.sh
+++ b/dev/generate-networks-file.sh
@@ -16,9 +16,13 @@ generated=$(jq --slurp --sort-keys '
   [ .[]
     | ran_at as $ran_at
     | (.chain | tostring) as $chain
+    | (.receipts | INDEX(.transactionHash)) as $receipts
     | .transactions[]
     | select(.transactionType == "CREATE" or .transactionType == "CREATE2")
     | select(.hash != null)
+    # A run that reverted, or never landed, must not become the published deployment. Runs that
+    # predate the receipt log are listed in networks-manual.json instead.
+    | select($receipts[.hash].status == "0x1")
     | [$ran_at, {(.contractName): {($chain): {address: .contractAddress, transactionHash: .hash}}}]
   ]
   # `sort_by` is stable, so a run keeps its own transaction order and the later one wins.

--- a/dev/generate-networks-file.sh
+++ b/dev/generate-networks-file.sh
@@ -5,27 +5,25 @@ set -o errexit -o pipefail -o nounset
 repo_root_dir="$(git rev-parse --show-toplevel)"
 manual_file="$repo_root_dir/broadcast/networks-manual.json"
 
-# Generate JSON from broadcast deployment files
-generated=$(for deployment in "$repo_root_dir/broadcast/"*"/"*"/"*".json"; do
-  # Extract chain ID from folder name
-  chain_id=${deployment%/*}
-  chain_id=${chain_id##*/}
+# One record per deployed contract, oldest first, so the newest run wins the merge below. Ordering
+# by run rather than by file path matters because several scripts deploy the same contract.
+# `CREATE` is accepted alongside `CREATE2` because `deploy_ComposableCowPoller.s.sol` omits the
+# salt, so the existing Gnosis Chain poller was deployed non-deterministically.
+generated=$(jq --slurp --sort-keys '
+  # Foundry recorded seconds in older runs and milliseconds in newer ones.
+  def ran_at: .timestamp | if . > 100000000000 then . / 1000 else . end;
 
-  # Extract contract info per chain. `CREATE` is accepted alongside `CREATE2` because the
-  # standalone `deploy_ComposableCowPoller.s.sol` omits the salt, so the existing Gnosis Chain
-  # poller was deployed non-deterministically.
-  jq --compact-output --arg chainId "$chain_id" '
-    # Foundry recorded seconds in older runs and milliseconds in newer ones.
-    (.timestamp | if . > 100000000000 then . / 1000 else . end | floor) as $ran_at
+  [ .[]
+    | ran_at as $ran_at
+    | (.chain | tostring) as $chain
     | .transactions[]
     | select(.transactionType == "CREATE" or .transactionType == "CREATE2")
     | select(.hash != null)
-    | [$ran_at, {(.contractName): {($chainId): {address: .contractAddress, transactionHash: .hash }}}]
-  ' <"$deployment"
-  # When the same contract appears more than once the most recent run wins. Ordering by run
-  # timestamp keeps that true across scripts, whose file paths sort arbitrarily. `sort_by` is
-  # stable, so a run's own transactions stay in order and the later one wins.
-done | jq --sort-keys --slurp 'sort_by(.[0]) | map(.[1]) | reduce .[] as $item ({}; . *= $item)')
+    | [$ran_at, {(.contractName): {($chain): {address: .contractAddress, transactionHash: .hash}}}]
+  ]
+  # `sort_by` is stable, so a run keeps its own transaction order and the later one wins.
+  | sort_by(.[0]) | map(.[1]) | reduce .[] as $item ({}; . *= $item)
+' "$repo_root_dir/broadcast/"*"/"*"/"*".json")
 
 # Merge with manual file if it exists
 if [[ -f "$manual_file" ]]; then

--- a/dev/generate-networks-file.sh
+++ b/dev/generate-networks-file.sh
@@ -5,38 +5,28 @@ set -o errexit -o pipefail -o nounset
 repo_root_dir="$(git rev-parse --show-toplevel)"
 manual_file="$repo_root_dir/broadcast/networks-manual.json"
 
-# Some networks can't be deployed to with the deployment scripts (see
-# https://github.com/cowprotocol/composable-cow/issues/93), so they have no broadcast artifacts to
-# read from. Those are recorded by hand in `broadcast/networks-manual.json`, which has the same
-# shape as `networks.json` and is merged on top of whatever the broadcast files produce.
-
-# Build the JSON out of the broadcast deployment artifacts.
+# Generate JSON from broadcast deployment files
 generated=$(for deployment in "$repo_root_dir/broadcast/"*"/"*"/"*".json"; do
-  # The subfolder name is the chain id
+  # Extract chain ID from folder name
   chain_id=${deployment%/*}
   chain_id=${chain_id##*/}
 
-  # First, every single deployment is formatted as if it had its own networks.json.
-  # `CREATE` is accepted alongside `CREATE2` because not every contract is deployed
-  # deterministically: `deploy_ComposableCowPoller.s.sol` takes a constructor argument and is
-  # deployed without a salt.
+  # Extract contract info per chain. `CREATE` is accepted alongside `CREATE2` because the
+  # standalone `deploy_ComposableCowPoller.s.sol` omits the salt, so the existing Gnosis Chain
+  # poller was deployed non-deterministically.
   jq --arg chainId "$chain_id" '
     .transactions[]
     | select(.transactionType == "CREATE" or .transactionType == "CREATE2")
     | select(.hash != null)
     | {(.contractName): {($chainId): {address: .contractAddress, transactionHash: .hash }}}
   ' <"$deployment"
-done \
-  | # Then, all these single-contract single-chain-id networks.jsons are merged. Note: in case the same contract is
-    # deployed twice in the same script run, the last deployed contract takes priority.
-    # If the same contract is deployed twice in different runs, the address in the file path that comes latest in
-    # alphabetical order takes priority. For example, a contract in `broadcast/Deployment10/*` is overwritten by
-    # one with the same name from `broadcast/Deployment2/*`. `run-latest.json` sorts after any `run-<timestamp>.json`,
-    # so the most recent run of a script wins.
-    jq --sort-keys --null-input 'reduce inputs as $item ({}; . *= $item)')
+  # When the same contract appears more than once, the last one wins: within a run, the latest
+  # deployment; across runs, the path that sorts last (so `run-latest.json` beats `run-<timestamp>.json`).
+done | jq --sort-keys --null-input 'reduce inputs as $item ({}; . *= $item)')
 
-# Merge the manually recorded deployments on top, if there are any.
+# Merge with manual file if it exists
 if [[ -f "$manual_file" ]]; then
+  # Validate that the manual file contains valid JSON
   if ! jq empty "$manual_file" 2>/dev/null; then
     echo "Error: $manual_file is not valid JSON." >&2
     exit 1

--- a/networks.json
+++ b/networks.json
@@ -35,7 +35,7 @@
   },
   "ComposableCowPoller": {
     "100": {
-      "address": "0x5Eda08425781c2C39A28fAAf963C79487dc91bb1",
+      "address": "0x5eda08425781c2c39a28faaf963c79487dc91bb1",
       "transactionHash": "0x432c451276714eacd524e2578afa05917bb6efbfdba386f1fa644cd58ab56cc3"
     }
   },


### PR DESCRIPTION
Closes the loop on https://github.com/cowprotocol/composable-cow/pull/103#issuecomment-3161290115.

`networks.json` has been maintained by hand since the generator script was deleted in #103. It was deleted because the Lens contracts were deployed manually and left no broadcast artifacts for the script to read, so the file had to be edited directly.

This PR restores the script

## Changes


- `broadcast/networks-manual.json`: 
   - chains deployed by hand, in the same shape as `networks.json`
   -  Today that is Lens (232), BNB (56), Linea (59144) and Plasma (9745)
- `dev/generate-networks-file.sh`: 
   -  Restores the original jq pipeline over `broadcast/*/*/*.json`
   -  Obviously, adapts it to take the `broadcast/networks-manual.json` intro account
- `networks.json`:
   - is regenerated now as a result of running the script
   - only change u see there is related to the casing. The script uses loweccase

## Test plan

Regenerate and confirm the file does not have changes:

```bash
bash dev/generate-networks-file.sh > networks.json
git diff --exit-code networks.json 
```

A CI check that enforces this invariant follows in a separate PR.

## Out of scope
Probably after these 2 PRs I want to revisit the script and see if it all work together. For now, im happy the networks.json can be reconstructed again from current state of the project.
- https://github.com/cowprotocol/composable-cow/pull/142
- https://github.com/cowprotocol/composable-cow/pull/141