### PR TITLE
fix: deploy ComposableCowPoller deterministically

### DIFF
--- a/script/deploy_ComposableCowPoller.s.sol
+++ b/script/deploy_ComposableCowPoller.s.sol
@@ -13,7 +13,7 @@ contract DeployComposableCowPoller is Script {
 
         vm.startBroadcast(deployerPrivateKey);
 
-        ComposableCowPoller poller = new ComposableCowPoller(ComposableCoW(composableCow));
+        ComposableCowPoller poller = new ComposableCowPoller{salt: "v1.0.0"}(ComposableCoW(composableCow));
 
         vm.stopBroadcast();
 


### PR DESCRIPTION
The standalone poller script deploys with a plain `new`, so it goes out via `CREATE` and the address depends on the deployer nonce. `deploy_ProdStack.s.sol:44` deploys the same contract with `{salt: "v1.0.0"}`, so which script you use decides whether the address is deterministic. This makes the standalone path match.

Note the other standalone scripts (`deploy_OrderTypes`, `deploy_ComposableCoW`, `deploy_ExtensibleFallbackHandler`, `deploy_ValueFactories`) omit the salt too. They're covered by the "won't deploy to the official addresses" warning in the readme; the poller's script isn't, since it's the only way to deploy a poller at all.

Future deploys only. The existing Gnosis poller `0x5eda08425781c2c39a28faaf963c79487dc91bb1` stays where it is, so anything reading the broadcast artifacts still needs to handle both `CREATE` and `CREATE2`. With this change the poller deploys to `0xa77102BE1D0c6eDc0980A896f78Aff7Dbb6CBA49` instead, given `COMPOSABLE_COW=0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74`.

## Test plan

`forge build` passes.

The new address was derived two independent ways, both agreeing:

```bash
# 1. from the locally compiled bytecode
cast create2 -d 0x4e59b44847b379578588920cA78FbF26c0B4956C \
  --salt "$(cast format-bytes32-string 'v1.0.0')" \
  --init-code "$(forge inspect src/types/ComposableCowPoller.sol:ComposableCowPoller bytecode)$(cast abi-encode 'f(address)' 0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74 | cut -c3-)"

# 2. from the initcode of the existing Gnosis deploy
cast tx 0x432c451276714eacd524e2578afa05917bb6efbfdba386f1fa644cd58ab56cc3 input --rpc-url https://rpc.gnosischain.com
```

The same method reproduces a known CREATE2 deployment exactly (TWAP on Gnosis -> `0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5`, matching `networks.json`).