### PR TITLE
fix: read only Foundry run artifacts when regenerating networks.json

### DIFF
--- a/dev/generate-networks-file.sh
+++ b/dev/generate-networks-file.sh
@@ -7,6 +7,8 @@ manual_file="$repo_root_dir/broadcast/networks-manual.json"
 
 # One record per deployed contract, oldest first, so the newest run wins the merge below. Ordering
 # by run rather than by file path matters because several scripts deploy the same contract.
+# Matched on Foundry's `run-` prefix rather than every nested `.json`, so an unrelated file under
+# `broadcast/` is skipped instead of being read as a run and failing on its missing fields.
 # `CREATE` is accepted alongside `CREATE2` because `deploy_ComposableCowPoller.s.sol` omits the
 # salt, so the existing Gnosis Chain poller was deployed non-deterministically.
 generated=$(jq --slurp --sort-keys '
@@ -27,7 +29,7 @@ generated=$(jq --slurp --sort-keys '
   ]
   # `sort_by` is stable, so a run keeps its own transaction order and the later one wins.
   | sort_by(.[0]) | map(.[1]) | reduce .[] as $item ({}; . *= $item)
-' "$repo_root_dir/broadcast/"*"/"*"/"*".json")
+' "$repo_root_dir/broadcast/"*"/"*"/run-"*".json")
 
 # Merge with manual file if it exists
 if [[ -f "$manual_file" ]]; then


### PR DESCRIPTION
Follow-up to #139 motivated by this comment https://github.com/cowprotocol/composable-cow/pull/141#discussion_r3772049100.


## How to test

Verify a regeneration of the networks would change nothing in `networks.json`
```
bash dev/generate-networks-file.sh | diff - networks.json
```

Create a empty json to mess up with the `generate-networks-file.sh`
This replicates what #141 is doing (adding a json with a different format there)

```
mkdir -p broadcast/canonical/999 && echo '{}' > broadcast/canonical/999/deployment.json
```

You can test this script breaks in `main`:
```bash
git show origin/main:dev/generate-networks-file.sh | bash 
```

Same test, should work in this branch, and should not create any changes in the `networls.json` file:
```
bash dev/generate-networks-file.sh | diff - networks.json 
```

Cleanup after your test:
```
rm -rf broadcast/canonical
```