### PR TITLE
feat(poller): add signed schedule revocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ Fortunately, when using Safe, it is possible to batch together all the above cal
 **TODO**
 **NOTE:** For canceling a TWAP order, follow the instructions at [Conditional order cancellation](#Conditional-order-cancellation).
 
+## Just-in-time funding with `ComposableCowPoller`
+
+`ComposableCowPoller` enables an EOA to create a ComposableCoW conditional order, such as a TWAP, without moving the full sell amount into the order's smart account up front. The funds remain in the EOA until each part is ready to trade. A pre-hook then calls `pollFunds`, which verifies that the order is still active and transfers only that part's sell amount to the smart account. Each part can be funded only once.
+
+The funder can register or revoke a funding schedule directly. To avoid a separate transaction, the funder can instead sign an EIP-712 authorization that a relayer submits on-chain. The Poller validates EOA signatures directly and uses ERC-1271 when the funder is a contract. Signed actions include a deadline and the current authorization epoch. Revocation derives the schedule ID from its funder, handler, owner, and salt, so it works before or after registration without allowing one funder to cancel another's schedule. It advances the authorization epoch, invalidating pending signatures from prior epochs while allowing the same schedule ID to be reused.
+
+Removing the conditional order from ComposableCoW stops further funding. Revoking its funding schedule does too, but does not remove the funder's token allowance; revoke that allowance separately when it is no longer needed.
+
 ## Developers
 
 ### Requirements

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -18,6 +18,10 @@ contract ComposableCowPoller is EIP712 {
         "ScheduleRegistration(address handler,uint96 authEpoch,address funder,address owner,bytes32 salt,bytes staticInput,uint256 deadline)"
     );
 
+    /// @dev EIP-712 Revoke struct typehash.
+    bytes32 public constant REVOKE_TYPEHASH =
+        keccak256("Revoke(address handler,uint96 authEpoch,address funder,address owner,bytes32 salt,uint256 deadline)");
+
     /// @dev `ComposableCoW` stores the settlement domain separator supplied at deployment.
     ComposableCoW public immutable COMPOSABLE_COW;
 
@@ -85,11 +89,14 @@ contract ComposableCowPoller is EIP712 {
     /// @param id The deterministic key of the schedule.
     /// @param owner The conditional-order owner and pull destination.
     /// @param funder The token source that registered the schedule.
+    /// @param authEpoch The schedule's authorization epoch.
     /// @param paramsHash The ComposableCoW order key this schedule funds. `id` deliberately excludes
     ///        `staticInput`, so re-registering the same funder, handler, owner, and salt replaces
     ///        the stored schedule. Logging the hash names the order each registration points at,
     ///        which is what makes such a replacement visible off-chain.
-    event ScheduleRegistered(bytes32 indexed id, address indexed owner, address indexed funder, bytes32 paramsHash);
+    event ScheduleRegistered(
+        bytes32 indexed id, address indexed owner, address indexed funder, uint96 authEpoch, bytes32 paramsHash
+    );
 
     /// @notice Emitted when a part's funds are moved.
     /// @dev `orderDigest` is indexed so a single leg can be looked up directly, rather than only
@@ -122,7 +129,7 @@ contract ComposableCowPoller is EIP712 {
     /// @param schedule The schedule whose identity fields determine the key.
     /// @return The schedule key.
     function scheduleId(Schedule memory schedule) public pure returns (bytes32) {
-        return keccak256(abi.encode(schedule.funder, schedule.handler, schedule.owner, schedule.salt));
+        return _scheduleId(schedule.funder, schedule.handler, schedule.owner, schedule.salt);
     }
 
     /// @notice Registers a schedule.
@@ -167,27 +174,75 @@ contract ComposableCowPoller is EIP712 {
         return _register(schedule);
     }
 
-    /// @dev Stores a schedule only in its current authorization epoch.
+    /// @dev Rejects overwriting an active schedule because it would make the previous order unfundable.
+    ///      Revoke first; funding history is retained to prevent replay.
+    ///      A zero owner or handler cannot satisfy `pollFunds`'s `singleOrders` check.
     function _register(ComposableCowPoller.Schedule calldata schedule) internal returns (bytes32 id) {
         id = scheduleId(schedule);
         if (schedules[id].funder != address(0)) revert AlreadyRegistered();
         if (schedule.authEpoch != schedules[id].authEpoch) revert InvalidAuthEpoch();
         schedules[id] = schedule;
         emit ScheduleRegistered(
-            id, schedule.owner, schedule.funder, _paramsHash(schedule.handler, schedule.salt, schedule.staticInput)
+            id,
+            schedule.owner,
+            schedule.funder,
+            schedule.authEpoch,
+            _paramsHash(schedule.handler, schedule.salt, schedule.staticInput)
         );
     }
 
-    /// @notice Revokes an active schedule.
-    /// @dev Only the funder may revoke. Clearing the schedule and incrementing `authEpoch` allows
-    ///      the same ID to be reused without allowing prior registration signatures to be replayed.
-    function revoke(bytes32 id) external {
-        Schedule storage schedule = schedules[id];
-        if (msg.sender != schedule.funder) revert OnlyFunder();
-        emit ScheduleRevoked(id, schedule.owner, schedule.funder);
-        uint96 nextAuthEpoch = schedule.authEpoch + 1;
+    /// @notice Revokes a schedule or cancels its current authorization epoch before registration.
+    /// @dev Uses `msg.sender` as funder, then clears the schedule and increments its `authEpoch`.
+    function revoke(IConditionalOrderGenerator handler, address owner, bytes32 salt) external returns (bytes32 id) {
+        id = _scheduleId(msg.sender, handler, owner, salt);
+        _revoke(id, msg.sender, owner, schedules[id].authEpoch);
+    }
+
+    /// @notice Revokes a schedule or cancels its current authorization epoch with a funder signature.
+    /// @dev Any caller may submit a valid signature before its deadline. The supplied `authEpoch`
+    ///      must match storage so signatures from earlier epochs cannot be reused.
+    /// @param handler The conditional-order handler identifying the schedule.
+    /// @param funder The schedule funder whose signature authorizes the revocation.
+    /// @param owner The conditional-order owner identifying the schedule.
+    /// @param salt The conditional order's salt identifying the schedule.
+    /// @param authEpoch The schedule's authorization epoch signed by the funder.
+    /// @param deadline The last block timestamp at which the signature is valid.
+    /// @param signature The funder's EIP-712 signature.
+    function revokeWithSignature(
+        IConditionalOrderGenerator handler,
+        address funder,
+        address owner,
+        bytes32 salt,
+        uint96 authEpoch,
+        uint256 deadline,
+        bytes calldata signature
+    ) external returns (bytes32 id) {
+        if (block.timestamp > deadline) revert SignatureExpired();
+
+        id = _scheduleId(funder, handler, owner, salt);
+        if (authEpoch != schedules[id].authEpoch) revert InvalidAuthEpoch();
+        bytes32 structHash = keccak256(abi.encode(REVOKE_TYPEHASH, handler, authEpoch, funder, owner, salt, deadline));
+        if (!SignatureChecker.isValidSignatureNow(funder, _hashTypedDataV4(structHash), signature)) {
+            revert InvalidSignature();
+        }
+
+        _revoke(id, funder, owner, authEpoch);
+    }
+
+    /// @dev Clears the schedule and increments its `authEpoch`, whether registered or not.
+    function _revoke(bytes32 id, address funder, address owner, uint96 authEpoch) internal {
+        emit ScheduleRevoked(id, owner, funder);
         delete schedules[id];
-        schedules[id].authEpoch = nextAuthEpoch;
+        schedules[id].authEpoch = authEpoch + 1;
+    }
+
+    /// @dev Derives the funder-namespaced ID, excluding `authEpoch` and `staticInput`.
+    function _scheduleId(address funder, IConditionalOrderGenerator handler, address owner, bytes32 salt)
+        internal
+        pure
+        returns (bytes32 id)
+    {
+        return keccak256(abi.encode(funder, handler, owner, salt));
     }
 
     /// @notice Hashes a schedule's `ConditionalOrderParams`, which is the order key it funds.

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -43,7 +43,9 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
     address funder;
     uint256 funderPrivateKey;
 
-    event ScheduleRegistered(bytes32 indexed id, address indexed owner, address indexed funder, bytes32 paramsHash);
+    event ScheduleRegistered(
+        bytes32 indexed id, address indexed owner, address indexed funder, uint96 authEpoch, bytes32 paramsHash
+    );
     event ScheduleRevoked(bytes32 indexed id, address indexed owner, address indexed funder);
     event Pulled(bytes32 indexed id, bytes32 indexed orderDigest, uint256 amount);
 
@@ -168,6 +170,48 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         return _sign(funderPrivateKey, _registerDigest(schedule, deadline, poller.domainSeparator()));
     }
 
+    function _revokeDigest(ComposableCowPoller.Schedule memory schedule, uint256 deadline, bytes32 domainSeparator)
+        internal
+        view
+        returns (bytes32)
+    {
+        bytes32 structHash = keccak256(
+            abi.encode(
+                poller.REVOKE_TYPEHASH(),
+                schedule.handler,
+                schedule.authEpoch,
+                schedule.funder,
+                schedule.owner,
+                schedule.salt,
+                deadline
+            )
+        );
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+    }
+
+    function _signRevoke(ComposableCowPoller.Schedule memory schedule, uint256 deadline)
+        internal
+        view
+        returns (bytes memory)
+    {
+        return _sign(funderPrivateKey, _revokeDigest(schedule, deadline, poller.domainSeparator()));
+    }
+
+    function _revoke(ComposableCowPoller.Schedule memory schedule) internal returns (bytes32 id) {
+        vm.prank(schedule.funder);
+        return poller.revoke(schedule.handler, schedule.owner, schedule.salt);
+    }
+
+    function _revokeWithSignature(
+        ComposableCowPoller.Schedule memory schedule,
+        uint256 deadline,
+        bytes memory signature
+    ) internal returns (bytes32 id) {
+        return poller.revokeWithSignature(
+            schedule.handler, schedule.funder, schedule.owner, schedule.salt, schedule.authEpoch, deadline, signature
+        );
+    }
+
     /// @dev The order's resolved start time `t0`, read back from the cabinet where
     ///      `createWithContext` stored it via `CurrentBlockTimestampFactory`.
     function _t0(bytes32 paramsHash) internal view returns (uint256) {
@@ -240,7 +284,7 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         bytes32 id = poller.scheduleId(schedule);
 
         vm.expectEmit(true, true, true, true, address(poller));
-        emit ScheduleRegistered(id, address(safe1), funder, _expectedParamsHash(SALT, firstInput));
+        emit ScheduleRegistered(id, address(safe1), funder, 0, _expectedParamsHash(SALT, firstInput));
         _register(schedule);
 
         TWAPOrder.Data memory other = _bundle();
@@ -251,13 +295,12 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         bytes32 secondParamsHash = _expectedParamsHash(SALT, secondInput);
         assertTrue(firstParamsHash != secondParamsHash, "the two orders have distinct keys");
 
-        vm.prank(funder);
-        poller.revoke(id);
+        _revoke(schedule);
 
         schedule.authEpoch = 1;
         schedule.staticInput = secondInput;
         vm.expectEmit(true, true, true, true, address(poller));
-        emit ScheduleRegistered(id, address(safe1), funder, secondParamsHash);
+        emit ScheduleRegistered(id, address(safe1), funder, 1, secondParamsHash);
         assertEq(_register(schedule), id, "same id as the schedule it replaced");
     }
 
@@ -274,6 +317,14 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
                 staticInput: abi.encode(_bundle())
             })
         );
+    }
+
+    function test_register_RevertWhen_staleAuthEpochAfterPreRegistrationRevoke() public {
+        ComposableCowPoller.Schedule memory schedule = _schedule(SALT, abi.encode(_bundle()));
+        _revoke(schedule);
+
+        vm.expectRevert(ComposableCowPoller.InvalidAuthEpoch.selector);
+        _register(schedule);
     }
 
     function test_registerWithSignature_allowsArbitraryCallerWithEOASignature() public {
@@ -434,9 +485,7 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         uint256 deadline = block.timestamp + 1 hours;
         bytes memory signature = _signRegister(schedule, deadline);
         bytes32 id = poller.registerWithSignature(schedule, deadline, signature);
-
-        vm.prank(funder);
-        poller.revoke(id);
+        _revoke(schedule);
 
         vm.expectRevert(ComposableCowPoller.InvalidAuthEpoch.selector);
         poller.registerWithSignature(schedule, deadline, signature);
@@ -449,15 +498,55 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         );
     }
 
+    function test_revoke_blocksPendingRegistrationSignature() public {
+        ComposableCowPoller.Schedule memory schedule = _schedule(SALT, abi.encode(_bundle()));
+        bytes32 id = poller.scheduleId(schedule);
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory signature = _signRegister(schedule, deadline);
+
+        vm.expectEmit(true, true, true, true, address(poller));
+        emit ScheduleRevoked(id, schedule.owner, funder);
+        assertEq(_revoke(schedule), id, "derived id returned");
+
+        (IConditionalOrderGenerator handler, uint96 authEpoch, address scheduleFunder, address owner,,) =
+            poller.schedules(id);
+        assertEq(address(handler), address(0), "no active schedule stored");
+        assertEq(authEpoch, 1, "authorization epoch advanced");
+        assertEq(scheduleFunder, address(0), "funder cleared");
+        assertEq(owner, address(0), "no owner stored");
+
+        vm.expectRevert(ComposableCowPoller.InvalidAuthEpoch.selector);
+        poller.registerWithSignature(schedule, deadline, signature);
+        schedule.authEpoch = 1;
+        assertEq(
+            poller.registerWithSignature(schedule, deadline, _signRegister(schedule, deadline)),
+            id,
+            "fresh signature registers"
+        );
+    }
+
+    function test_revoke_cannotCancelAnotherFundersSignature() public {
+        ComposableCowPoller.Schedule memory schedule = _schedule(SALT, abi.encode(_bundle()));
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory signature = _signRegister(schedule, deadline);
+
+        vm.prank(bob.addr);
+        bytes32 bobId = poller.revoke(schedule.handler, schedule.owner, schedule.salt);
+
+        bytes32 funderId = poller.scheduleId(schedule);
+        assertTrue(bobId != funderId, "schedule IDs are namespaced by funder");
+        assertEq(poller.registerWithSignature(schedule, deadline, signature), funderId);
+    }
+
     /// @dev The funder can revoke, which clears active data and advances the authorization epoch.
     function test_revoke_clearsSchedule() public {
         (,, bytes32 id) = _setupSchedule();
+        ComposableCowPoller.Schedule memory schedule = _schedule(SALT, abi.encode(_bundle()));
 
         vm.expectEmit(true, true, true, true, address(poller));
         emit ScheduleRevoked(id, address(safe1), funder);
 
-        vm.prank(funder);
-        poller.revoke(id);
+        assertEq(_revoke(schedule), id, "registered id returned");
 
         (
             IConditionalOrderGenerator handler,
@@ -475,12 +564,102 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         assertEq(staticInput, bytes(""), "static input cleared");
     }
 
-    /// @dev Only the funds source may revoke.
-    function test_revoke_RevertWhen_notFunder() public {
-        (,, bytes32 id) = _setupSchedule();
+    function test_revokeWithSignature_allowsArbitraryCallerWithEOASignature() public {
+        ComposableCowPoller.Schedule memory schedule = _schedule(SALT, abi.encode(_bundle()));
+        bytes32 id = _register(schedule);
+        uint256 deadline = block.timestamp + 1 hours;
 
-        vm.expectRevert(ComposableCowPoller.OnlyFunder.selector);
-        poller.revoke(id);
+        vm.expectEmit(true, true, true, true, address(poller));
+        emit ScheduleRevoked(id, address(safe1), funder);
+        vm.prank(bob.addr);
+        assertEq(_revokeWithSignature(schedule, deadline, _signRevoke(schedule, deadline)), id, "id returned");
+
+        (IConditionalOrderGenerator handler, uint96 authEpoch, address scheduleFunder, address owner,,) =
+            poller.schedules(id);
+        assertEq(address(handler), address(0), "handler cleared");
+        assertEq(authEpoch, 1, "authorization epoch advanced");
+        assertEq(scheduleFunder, address(0), "funder cleared");
+        assertEq(owner, address(0), "owner cleared");
+    }
+
+    function test_revokeWithSignature_allowsERC1271Signature() public {
+        TestPollerERC1271Signer signer = new TestPollerERC1271Signer();
+        ComposableCowPoller.Schedule memory schedule = _schedule(SALT, abi.encode(_bundle()));
+        schedule.funder = address(signer);
+        bytes32 id = _register(schedule);
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory signature = hex"c0ffee";
+        signer.allow(_revokeDigest(schedule, deadline, poller.domainSeparator()), signature);
+
+        vm.prank(bob.addr);
+        _revokeWithSignature(schedule, deadline, signature);
+
+        (IConditionalOrderGenerator handler, uint96 authEpoch, address scheduleFunder,,,) = poller.schedules(id);
+        assertEq(address(handler), address(0), "handler cleared");
+        assertEq(authEpoch, 1, "authorization epoch advanced");
+        assertEq(scheduleFunder, address(0), "funder cleared");
+    }
+
+    function test_revokeWithSignature_RevertWhen_expired() public {
+        ComposableCowPoller.Schedule memory schedule = _schedule(SALT, abi.encode(_bundle()));
+        bytes32 id = _register(schedule);
+        vm.warp(1 days);
+        uint256 deadline = block.timestamp - 1;
+        bytes memory signature = _signRevoke(schedule, deadline);
+
+        vm.expectRevert(ComposableCowPoller.SignatureExpired.selector);
+        _revokeWithSignature(schedule, deadline, signature);
+
+        (IConditionalOrderGenerator handler,,, address owner,,) = poller.schedules(id);
+        assertEq(address(handler), address(twap), "schedule remains active");
+        assertEq(owner, address(safe1), "owner retained");
+    }
+
+    function test_revokeWithSignature_RevertWhen_scheduleChanges() public {
+        ComposableCowPoller.Schedule memory signedSchedule = _schedule(SALT, abi.encode(_bundle()));
+        bytes32 signedId = _register(signedSchedule);
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory signature = _signRevoke(signedSchedule, deadline);
+        ComposableCowPoller.Schedule memory changedSchedule = signedSchedule;
+        changedSchedule.salt = SECOND_SALT;
+
+        vm.expectRevert(ComposableCowPoller.InvalidSignature.selector);
+        _revokeWithSignature(changedSchedule, deadline, signature);
+
+        (IConditionalOrderGenerator handler,,,,,) = poller.schedules(signedId);
+        assertEq(address(handler), address(twap), "signed schedule remains active");
+    }
+
+    function test_revokeWithSignature_blocksPendingRegistrationSignature() public {
+        ComposableCowPoller.Schedule memory schedule = _schedule(SALT, abi.encode(_bundle()));
+        bytes32 id = poller.scheduleId(schedule);
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory registerSignature = _signRegister(schedule, deadline);
+
+        vm.prank(bob.addr);
+        assertEq(_revokeWithSignature(schedule, deadline, _signRevoke(schedule, deadline)), id, "derived id returned");
+
+        vm.expectRevert(ComposableCowPoller.InvalidAuthEpoch.selector);
+        poller.registerWithSignature(schedule, deadline, registerSignature);
+    }
+
+    function test_revokeWithSignature_RevertWhen_scheduleRecreatedInNewAuthEpoch() public {
+        ComposableCowPoller.Schedule memory schedule = _schedule(SALT, abi.encode(_bundle()));
+        bytes32 id = _register(schedule);
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory signature = _signRevoke(schedule, deadline);
+
+        _revoke(schedule);
+        ComposableCowPoller.Schedule memory recreatedSchedule = _schedule(SALT, abi.encode(_bundle()));
+        recreatedSchedule.authEpoch = 1;
+        _register(recreatedSchedule);
+
+        vm.expectRevert(ComposableCowPoller.InvalidAuthEpoch.selector);
+        _revokeWithSignature(schedule, deadline, signature);
+
+        (IConditionalOrderGenerator handler, uint96 authEpoch,,,,) = poller.schedules(id);
+        assertEq(address(handler), address(twap), "new authorization epoch remains active");
+        assertEq(authEpoch, 1, "new authorization epoch retained");
     }
 
     /// @dev Funds move unconditionally: even if the owner already holds a balance (e.g. from another
@@ -548,8 +727,7 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         vm.prank(address(safe1));
         assertTrue(token0.transfer(bob.addr, TWAP_PART_AMOUNT), "second order settled");
 
-        vm.prank(funder);
-        poller.revoke(id);
+        _revoke(schedule);
 
         schedule.authEpoch = 1;
         assertEq(_register(schedule), id, "same schedule id");


### PR DESCRIPTION
# Description

Funders can revoke polling schedules through relayers with an EIP-712 signature. This forwards the reviewed PR #136 change, which was accidentally merged into its stacked feature branch, onto `main`.

# Changes

- [x] Add signed schedule revocation for EOA and ERC-1271 signatures.
- [x] Bind revocation authorization to the schedule ID, funder, deadline, and auth epoch.
- [x] Preserve the accepted PR #135 follow-up fixes required by the final implementation.

## How to test

1. Run `forge test --offline --match-contract ComposableCowPollerTest`.
2. Confirm all 38 tests pass.

Related: #136
