### PR TITLE
chore: drop unused imports from the tests and scripts

### DIFF
--- a/script/deploy_AnvilStack.s.sol
+++ b/script/deploy_AnvilStack.s.sol
@@ -7,11 +7,9 @@ import {Script, console} from "forge-std/Script.sol";
 import {IVault} from "cowprotocol/contracts/interfaces/IVault.sol";
 import {GPv2Settlement} from "cowprotocol/contracts/GPv2Settlement.sol";
 import {GPv2AllowListAuthentication} from "cowprotocol/contracts/GPv2AllowListAuthentication.sol";
-import {GPv2Authentication} from "cowprotocol/contracts/interfaces/GPv2Authentication.sol";
 
 // Safe contracts
 import {Safe} from "safe/Safe.sol";
-import {Enum} from "safe/common/Enum.sol";
 import {SafeProxyFactory, SafeProxy} from "safe/proxies/SafeProxyFactory.sol";
 import {CompatibilityFallbackHandler} from "safe/handler/CompatibilityFallbackHandler.sol";
 import {MultiSend} from "safe/libraries/MultiSend.sol";

--- a/script/submit_SingleOrder.s.sol
+++ b/script/submit_SingleOrder.s.sol
@@ -8,11 +8,6 @@ import {IERC20} from "cowprotocol/contracts/interfaces/IERC20.sol";
 // Safe contracts
 import {Safe} from "safe/Safe.sol";
 import {Enum} from "safe/common/Enum.sol";
-import {SafeProxyFactory} from "safe/proxies/SafeProxyFactory.sol";
-import {CompatibilityFallbackHandler} from "safe/handler/CompatibilityFallbackHandler.sol";
-import {MultiSend} from "safe/libraries/MultiSend.sol";
-import {SignMessageLib} from "safe/libraries/SignMessageLib.sol";
-import {ExtensibleFallbackHandler} from "safe/handler/ExtensibleFallbackHandler.sol";
 import {SafeLib} from "../test/libraries/SafeLib.t.sol";
 
 // Composable CoW

--- a/test/ComposableCoW.base.t.sol
+++ b/test/ComposableCoW.base.t.sol
@@ -7,7 +7,6 @@ import {Safe, IERC165, Enum} from "safe/Safe.sol";
 
 // Testing Libraries
 import {Base} from "./Base.t.sol";
-import {TestAccount, TestAccountLib} from "./libraries/TestAccountLib.t.sol";
 import {SafeLib} from "./libraries/SafeLib.t.sol";
 import {ComposableCoWLib} from "./libraries/ComposableCoWLib.t.sol";
 
@@ -15,7 +14,6 @@ import {IConditionalOrder, IERC20, BaseConditionalOrder, INVALID_HASH} from "../
 import {BaseSwapGuard} from "../src/guards/BaseSwapGuard.sol";
 
 import {TWAP, TWAPOrder} from "../src/types/twap/TWAP.sol";
-import {GoodAfterTime} from "../src/types/GoodAfterTime.sol";
 import {ERC1271Forwarder} from "../src/ERC1271Forwarder.sol";
 import {ReceiverLock} from "../src/guards/ReceiverLock.sol";
 

--- a/test/ComposableCoW.gat.t.sol
+++ b/test/ComposableCoW.gat.t.sol
@@ -10,7 +10,6 @@ import {
     Safe,
     SafeLib,
     BaseComposableCoWTest,
-    ComposableCoW,
     ComposableCoWLib
 } from "./ComposableCoW.base.t.sol";
 

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -23,7 +23,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         stopLoss = new StopLoss();
     }
 
-    function priceToAddress(int256 price) internal returns (address) {
+    function priceToAddress(int256 price) internal pure returns (address) {
         return address(uint160(int160(price)));
     }
 

--- a/test/ComposableCoW.tat.t.sol
+++ b/test/ComposableCoW.tat.t.sol
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {ERC1271} from "safe/handler/extensible/SignatureVerifierMuxer.sol";
 
 import "./ComposableCoW.base.t.sol";
 
 import "../src/types/TradeAboveThreshold.sol";
-import {ConditionalOrdersUtilsLib as Utils} from "../src/types/ConditionalOrdersUtilsLib.sol";
 
 contract ComposableCoWTatTest is BaseComposableCoWTest {
     using ComposableCoWLib for IConditionalOrder.ConditionalOrderParams[];

--- a/test/ComposableCoW.twap.t.sol
+++ b/test/ComposableCoW.twap.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {ERC1271} from "safe/handler/extensible/SignatureVerifierMuxer.sol";
 
 import {

--- a/test/helpers/CoWProtocol.t.sol
+++ b/test/helpers/CoWProtocol.t.sol
@@ -13,7 +13,6 @@ import {
     GPv2Signing
 } from "cowprotocol/contracts/GPv2Settlement.sol";
 import {GPv2AllowListAuthentication} from "cowprotocol/contracts/GPv2AllowListAuthentication.sol";
-import {GPv2Authentication} from "cowprotocol/contracts/interfaces/GPv2Authentication.sol";
 
 import {GPv2TradeEncoder} from "../vendored/GPv2TradeEncoder.sol";
 import {TestAccount, TestAccountLib} from "../libraries/TestAccountLib.t.sol";

--- a/test/helpers/Safe.t.sol
+++ b/test/helpers/Safe.t.sol
@@ -10,7 +10,7 @@ import {SignMessageLib} from "safe/libraries/SignMessageLib.sol";
 import {ExtensibleFallbackHandler, FallbackHandler, MarshalLib} from "safe/handler/ExtensibleFallbackHandler.sol";
 
 import {SafeLib} from "../libraries/SafeLib.t.sol";
-import {TestAccount, TestAccountLib} from "../libraries/TestAccountLib.t.sol";
+import {TestAccount} from "../libraries/TestAccountLib.t.sol";
 
 /**
  * @title Safe - A helper contract for local integration testing with `Safe`.

--- a/test/libraries/ComposableCoWLib.t.sol
+++ b/test/libraries/ComposableCoWLib.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {Merkle} from "murky/Merkle.sol";
 import {IConditionalOrder} from "../../src/interfaces/IConditionalOrder.sol";
 
 library ComposableCoWLib {

--- a/test/libraries/SafeLib.t.sol
+++ b/test/libraries/SafeLib.t.sol
@@ -5,9 +5,6 @@ import {Enum} from "safe/common/Enum.sol";
 import {Safe} from "safe/Safe.sol";
 import {SafeProxy} from "safe/proxies/SafeProxy.sol";
 import {SafeProxyFactory} from "safe/proxies/SafeProxyFactory.sol";
-import {CompatibilityFallbackHandler} from "safe/handler/CompatibilityFallbackHandler.sol";
-import {MultiSend} from "safe/libraries/MultiSend.sol";
-import {SignMessageLib} from "safe/libraries/SignMessageLib.sol";
 
 import {TestAccount, TestAccountLib} from "../libraries/TestAccountLib.t.sol";
 

--- a/test/vendored/GPv2TradeEncoder.sol
+++ b/test/vendored/GPv2TradeEncoder.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
 import {GPv2Order} from "cowprotocol/contracts/libraries/GPv2Order.sol";
 import {GPv2Signing} from "cowprotocol/contracts/mixins/GPv2Signing.sol";


### PR DESCRIPTION
Remove WARNINGS from the build

## Context
`forge build` is noisy. 

This clears the mechanical part of it in `test/` and `script/`: 19 unused imports, plus a test helper that can be `pure` 

The only solc warning raised outside the submodules.

## Out of scope
Nothing in `src/` is touched to make review simpler. Some warning remains, we could review this in a follow up PR if we wish. Note this might be more tricky cause could change the bytecode, making it not deterministic and braking the legacy deployments.

Three `unused-import` notes remain in `ComposableCoW.base.t.sol`: `IERC165`, `ReceiverLock` and `INVALID_HASH` are re-exported to the subclasses that import from it, and removing them fails to compile. 

The remaining `unsafe-typecast` and import-style notes are left alone rather than papered over with suppression comments.

## Test plan

```sh
forge build --force
forge test
```
