### PR TITLE
chore: remove the last unused imports, reaching zero lint findings

### DIFF
--- a/src/BaseConditionalOrder.sol
+++ b/src/BaseConditionalOrder.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
-import {GPv2Order, IERC20} from "cowprotocol/contracts/libraries/GPv2Order.sol";
+import {GPv2Order} from "cowprotocol/contracts/libraries/GPv2Order.sol";
 
 import {IERC165, IConditionalOrder, IConditionalOrderGenerator} from "./interfaces/IConditionalOrder.sol";
 

--- a/src/interfaces/IConditionalOrder.sol
+++ b/src/interfaces/IConditionalOrder.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import {GPv2Order} from "cowprotocol/contracts/libraries/GPv2Order.sol";
-import {GPv2Interaction} from "cowprotocol/contracts/libraries/GPv2Interaction.sol";
 import {IERC165} from "safe/interfaces/IERC165.sol";
 
 /**

--- a/src/types/GoodAfterTime.sol
+++ b/src/types/GoodAfterTime.sol
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
+import {IERC20} from "cowprotocol/contracts/interfaces/IERC20.sol";
+
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import {IExpectedOutCalculator} from "../vendored/Milkman.sol";
-import {IERC20, IConditionalOrder, GPv2Order, BaseConditionalOrder} from "../BaseConditionalOrder.sol";
+import {IConditionalOrder, GPv2Order, BaseConditionalOrder} from "../BaseConditionalOrder.sol";
 import {ConditionalOrdersUtilsLib as Utils} from "./ConditionalOrdersUtilsLib.sol";
 
 // --- error strings

--- a/src/types/PerpetualStableSwap.sol
+++ b/src/types/PerpetualStableSwap.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
+import {IERC20} from "cowprotocol/contracts/interfaces/IERC20.sol";
+
 import {
-    IERC20,
     GPv2Order,
     IConditionalOrder,
     IConditionalOrderGenerator,

--- a/src/types/StopLoss.sol
+++ b/src/types/StopLoss.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {IERC20, GPv2Order, IConditionalOrder, BaseConditionalOrder} from "../BaseConditionalOrder.sol";
+import {IERC20} from "cowprotocol/contracts/interfaces/IERC20.sol";
+
+import {GPv2Order, IConditionalOrder, BaseConditionalOrder} from "../BaseConditionalOrder.sol";
 import {IAggregatorV3Interface} from "../interfaces/IAggregatorV3Interface.sol";
 import {ConditionalOrdersUtilsLib as Utils} from "./ConditionalOrdersUtilsLib.sol";
 

--- a/src/types/TradeAboveThreshold.sol
+++ b/src/types/TradeAboveThreshold.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
+import {IERC20} from "cowprotocol/contracts/interfaces/IERC20.sol";
+
 import {
-    IERC20,
     GPv2Order,
     IConditionalOrder,
     IConditionalOrderGenerator,

--- a/test/ComposableCoW.base.t.sol
+++ b/test/ComposableCoW.base.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
+import {IERC20} from "cowprotocol/contracts/interfaces/IERC20.sol";
+
 import {Merkle} from "murky/Merkle.sol";
 
 import {Safe, Enum} from "safe/Safe.sol";
@@ -10,7 +12,7 @@ import {Base} from "./Base.t.sol";
 import {SafeLib} from "./libraries/SafeLib.t.sol";
 import {ComposableCoWLib} from "./libraries/ComposableCoWLib.t.sol";
 
-import {IConditionalOrder, IERC20, BaseConditionalOrder} from "../src/BaseConditionalOrder.sol";
+import {IConditionalOrder, BaseConditionalOrder} from "../src/BaseConditionalOrder.sol";
 import {BaseSwapGuard} from "../src/guards/BaseSwapGuard.sol";
 
 import {TWAP, TWAPOrder} from "../src/types/twap/TWAP.sol";


### PR DESCRIPTION
Stacked on #152 (which disable some lint lines for some code we can't change).

This PR tries to reduce the WARN to zero, still no bytecode changes

## Test plan

Finally, no lint issues!
You will see some WARNINGS thought, these will be dealt with in https://github.com/cowprotocol/composable-cow/pull/154
```sh
forge lint
```


Test pass
```sh
forge test
```


Lastly check the canonitcal address didn't change:
```sh
ETH_RPC_URL=<rpc for gnosis>
bash dev/deploy-canonical.sh --rpc-url $ETH_RPC_URL
```

Should give you the canonical addresses:
```sh
Chain id: 100
Deterministic deployment proxy: present
GPv2Settlement: present at 0x9008d19f58aabd9ed0d60971565aa8510560ab41, domain separator matches chain 100

Verifying recorded initcode...
All recorded initcode matches the canonical addresses.

ComposableCoW                  0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74  already deployed
CurrentBlockTimestampFactory   0x52eD56Da04309Aca4c3FECC595298d80C2f16BAc  already deployed
ExtensibleFallbackHandler      0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5  already deployed
GoodAfterTime                  0xdaf33924925e03c9cc3a10d434016d6cfad0add5  already deployed
PerpetualStableSwap            0x519BA24e959E33b3B6220CA98bd353d8c2D89920  already deployed
StopLoss                       0x412c36e5011cd2517016d243a2dfb37f73a242e7  already deployed
TWAP                           0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5  already deployed
TradeAboveThreshold            0x812308712a6d1367f437e1c1e4af85c854e1e9f6  already deployed
```

