### PR TITLE
chore: suppress the lint findings we are not going to act on

### DIFF
--- a/src/ComposableCoW.sol
+++ b/src/ComposableCoW.sol
@@ -53,6 +53,7 @@ contract ComposableCoW is ISafeSignatureVerifier {
 
     // --- state
     // Domain separator is only used for generating signatures
+    // forge-lint: disable-next-line(screaming-snake-case-immutable) -- renaming desyncs the ABI from the deployed contract, see #151
     bytes32 public immutable domainSeparator;
     /// @dev Mapping of owner's merkle roots
     mapping(address => bytes32) public roots;
@@ -275,6 +276,7 @@ contract ComposableCoW is ISafeSignatureVerifier {
      * @return hash of the conditional order parameters
      */
     function hash(IConditionalOrder.ConditionalOrderParams memory params) public pure returns (bytes32) {
+        // forge-lint: disable-next-line(asm-keccak256) -- src/ must keep matching the deployed runtime code, see #151
         return keccak256(abi.encode(params));
     }
 
@@ -294,6 +296,7 @@ contract ComposableCoW is ISafeSignatureVerifier {
     {
         if (proof.length != 0) {
             /// @dev Computing proof using leaf double hashing
+            // forge-lint: disable-next-line(asm-keccak256) -- src/ must keep matching the deployed runtime code, see #151
             bytes32 leaf = keccak256(bytes.concat(hash(params)));
 
             // Check if the proof is valid

--- a/src/ERC1271Forwarder.sol
+++ b/src/ERC1271Forwarder.sol
@@ -12,6 +12,7 @@ import {ComposableCoW} from "./ComposableCoW.sol";
  * @dev Designed to be extended from by a contract that wants to use ComposableCoW
  */
 abstract contract ERC1271Forwarder is ERC1271 {
+    // forge-lint: disable-next-line(screaming-snake-case-immutable) -- integration surface; renaming breaks contracts that inherit this
     ComposableCoW public immutable composableCoW;
 
     constructor(ComposableCoW _composableCoW) {

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -210,6 +210,7 @@ contract ComposableCowPoller is EIP712 {
     ) external returns (bytes32 id) {
         if (block.timestamp > deadline) revert SignatureExpired();
 
+        // forge-lint: disable-next-item(asm-keccak256) -- gas only; plain Solidity is worth more here than the saving
         bytes32 structHash = keccak256(
             abi.encode(
                 SCHEDULE_REGISTRATION_TYPEHASH,
@@ -306,6 +307,7 @@ contract ComposableCowPoller is EIP712 {
 
         id = _scheduleId(funder, handler, owner, salt);
         if (authEpoch != schedules[id].authEpoch) revert InvalidAuthEpoch();
+        // forge-lint: disable-next-item(asm-keccak256) -- gas only; plain Solidity is worth more here than the saving
         bytes32 structHash = keccak256(
             abi.encode(
                 REVOKE_TYPEHASH,
@@ -388,6 +390,7 @@ contract ComposableCowPoller is EIP712 {
         address owner,
         bytes32 salt
     ) internal pure returns (bytes32 id) {
+        // forge-lint: disable-next-line(asm-keccak256) -- gas only; plain Solidity is worth more here than the saving
         return keccak256(abi.encode(funder, handler, owner, salt));
     }
 
@@ -404,6 +407,7 @@ contract ComposableCowPoller is EIP712 {
         bytes32 salt,
         bytes memory staticInput
     ) internal pure returns (bytes32) {
+        // forge-lint: disable-next-item(asm-keccak256) -- gas only; plain Solidity is worth more here than the saving
         return
             keccak256(
                 abi.encode(

--- a/src/types/ConditionalOrdersUtilsLib.sol
+++ b/src/types/ConditionalOrdersUtilsLib.sol
@@ -13,6 +13,7 @@ library ConditionalOrdersUtilsLib {
      * @param validity The width of the validity bucket in seconds.
      */
     function validToBucket(uint32 validity) internal view returns (uint32 validTo) {
+        // forge-lint: disable-next-line(divide-before-multiply) -- flooring to the start of the bucket is the point
         validTo = ((uint32(block.timestamp) / validity) * validity) + validity;
     }
 

--- a/src/types/twap/TWAP.sol
+++ b/src/types/twap/TWAP.sol
@@ -25,6 +25,7 @@ string constant NOT_WITHIN_SPAN = "not within span";
  * @dev Designed to be used with the CoW Protocol Conditional Order Framework.
  */
 contract TWAP is BaseConditionalOrder {
+    // forge-lint: disable-next-line(screaming-snake-case-immutable) -- renaming desyncs the ABI from the deployed contract, see #151
     ComposableCoW public immutable composableCow;
 
     constructor(ComposableCoW _composableCow) {


### PR DESCRIPTION

Disable lint for legacy contract dafe WARNINGs.

## Context

The compiler is very noisy. I'm fixing the WARNs, but for the legacy contracts this is problematic.

`ComposableCoW` and `TWAP` are deployed from the frozen initcode in `canonical/`, and per that folder's readme `src/` still compiles to their runtime code 

Fixing the lint issues yield a different bytecode. 

Suppressed at the four sites instead of disabling the rules, so new code still gets flagged. 

Tracked in #151 the reminder of killing this in the future once we can get rid of the "canonical" directory.


## Test plan

```sh
forge lint
```

Lint should only show now a couple of lint issues that will be gone in https://github.com/cowprotocol/composable-cow/pull/150


```sh
forge test
```

Should pass


Lastly check the canonitcal address didn't change:
```sh
ETH_RPC_URL=<rpc for gnosis>
bash dev/deploy-canonical.sh --rpc-url $ETH_RPC_URL
```

Should give you the canonical addresses:
```sh
Chain id: 100
Deterministic deployment proxy: present
GPv2Settlement: present at 0x9008d19f58aabd9ed0d60971565aa8510560ab41, domain separator matches chain 100

Verifying recorded initcode...
All recorded initcode matches the canonical addresses.

ComposableCoW                  0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74  already deployed
CurrentBlockTimestampFactory   0x52eD56Da04309Aca4c3FECC595298d80C2f16BAc  already deployed
ExtensibleFallbackHandler      0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5  already deployed
GoodAfterTime                  0xdaf33924925e03c9cc3a10d434016d6cfad0add5  already deployed
PerpetualStableSwap            0x519BA24e959E33b3B6220CA98bd353d8c2D89920  already deployed
StopLoss                       0x412c36e5011cd2517016d243a2dfb37f73a242e7  already deployed
TWAP                           0x6cF1e9cA41f7611dEf408122793c358a3d11E5a5  already deployed
TradeAboveThreshold            0x812308712a6d1367f437e1c1e4af85c854e1e9f6  already deployed
```


## Approval of the PR
<img width="964" height="126" alt="image" src="https://github.com/user-attachments/assets/e6ff4cf3-11ea-405c-b830-0ea2e9c4d410" />

Was approved, but rebasing the branch marked as stale. No changes were added after. This is why is merged