### PR TITLE
chore: fix the lint findings in the tests

### DIFF
--- a/test/ComposableCoW.base.t.sol
+++ b/test/ComposableCoW.base.t.sol
@@ -3,19 +3,18 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import {Merkle} from "murky/Merkle.sol";
 
-import {Safe, IERC165, Enum} from "safe/Safe.sol";
+import {Safe, Enum} from "safe/Safe.sol";
 
 // Testing Libraries
 import {Base} from "./Base.t.sol";
 import {SafeLib} from "./libraries/SafeLib.t.sol";
 import {ComposableCoWLib} from "./libraries/ComposableCoWLib.t.sol";
 
-import {IConditionalOrder, IERC20, BaseConditionalOrder, INVALID_HASH} from "../src/BaseConditionalOrder.sol";
+import {IConditionalOrder, IERC20, BaseConditionalOrder} from "../src/BaseConditionalOrder.sol";
 import {BaseSwapGuard} from "../src/guards/BaseSwapGuard.sol";
 
 import {TWAP, TWAPOrder} from "../src/types/twap/TWAP.sol";
 import {ERC1271Forwarder} from "../src/ERC1271Forwarder.sol";
-import {ReceiverLock} from "../src/guards/ReceiverLock.sol";
 
 import {IValueFactory} from "../src/interfaces/IValueFactory.sol";
 

--- a/test/ComposableCoW.gat.t.sol
+++ b/test/ComposableCoW.gat.t.sol
@@ -3,6 +3,8 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import {ERC1271} from "safe/handler/extensible/SignatureVerifierMuxer.sol";
 
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
 import {
     IERC20,
     GPv2Order,
@@ -161,7 +163,7 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
             receiver: receiver,
             sellAmount: sellAmount,
             buyAmount: buyAmount,
-            validTo: uint32(endTime),
+            validTo: SafeCast.toUint32(endTime),
             appData: keccak256("GoodAfterTime"),
             feeAmount: 0, // zero fee for limit order
             kind: GPv2Order.KIND_SELL,

--- a/test/ComposableCoW.guards.t.sol
+++ b/test/ComposableCoW.guards.t.sol
@@ -2,16 +2,16 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import {ERC1271} from "safe/handler/extensible/SignatureVerifierMuxer.sol";
+import {IERC165} from "safe/interfaces/IERC165.sol";
+import {ReceiverLock} from "../src/guards/ReceiverLock.sol";
 
 import {
-    IERC165,
     IConditionalOrder,
     GPv2Order,
     ComposableCoW,
     BaseComposableCoWTest,
     ISwapGuard,
-    TestSwapGuard,
-    ReceiverLock
+    TestSwapGuard
 } from "./ComposableCoW.base.t.sol";
 
 contract ComposableCoWGuardsTest is BaseComposableCoWTest {

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -23,10 +23,6 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         stopLoss = new StopLoss();
     }
 
-    function priceToAddress(int256 price) internal pure returns (address) {
-        return address(uint160(int160(price)));
-    }
-
     function mockOracle(address mock, int256 price, uint256 updatedAt, uint8 decimals)
         internal
         returns (IAggregatorV3Interface iface)

--- a/test/ComposableCoW.t.sol
+++ b/test/ComposableCoW.t.sol
@@ -2,17 +2,19 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import {ERC1271} from "safe/handler/extensible/SignatureVerifierMuxer.sol";
+import {INVALID_HASH} from "../src/BaseConditionalOrder.sol";
 
 import {
     IConditionalOrder,
     GPv2Order,
     ComposableCoW,
     ComposableCoWLib,
-    INVALID_HASH,
     BaseComposableCoWTest,
     Safe,
     TestNonSafeWallet
 } from "./ComposableCoW.base.t.sol";
+
+bytes32 constant TEST_VALUE = "testValue";
 
 contract ComposableCoWTest is BaseComposableCoWTest {
     using ComposableCoWLib for IConditionalOrder.ConditionalOrderParams[];
@@ -94,7 +96,7 @@ contract ComposableCoWTest is BaseComposableCoWTest {
 
         // should set the root correctly
         ComposableCoW.Proof memory proofStruct = ComposableCoW.Proof({location: 0, data: ""});
-        _setRootWithContext(address(safe1), root, proofStruct, testContextValue, abi.encode(bytes32("testValue")));
+        _setRootWithContext(address(safe1), root, proofStruct, testContextValue, abi.encode(TEST_VALUE));
 
         // should pass with the root correctly set
         (GPv2Order.Data memory order, bytes memory signature) =

--- a/test/ComposableCoW.tat.t.sol
+++ b/test/ComposableCoW.tat.t.sol
@@ -2,9 +2,15 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 
-import "./ComposableCoW.base.t.sol";
-
-import "../src/types/TradeAboveThreshold.sol";
+import {
+    BaseComposableCoWTest,
+    ComposableCoWLib,
+    IConditionalOrder,
+    GPv2Order,
+    Safe,
+    SafeLib
+} from "./ComposableCoW.base.t.sol";
+import {TradeAboveThreshold, BALANCE_INSUFFICIENT} from "../src/types/TradeAboveThreshold.sol";
 
 contract ComposableCoWTatTest is BaseComposableCoWTest {
     using ComposableCoWLib for IConditionalOrder.ConditionalOrderParams[];

--- a/test/ComposableCoW.twap.t.sol
+++ b/test/ComposableCoW.twap.t.sol
@@ -512,7 +512,7 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
                 // only count this second if we didn't revert
                 numSecsProcessed++;
             } catch (bytes memory lowLevelData) {
-                bytes4 receivedSelector = bytes4(lowLevelData);
+                bytes4 receivedSelector = _selector(lowLevelData);
 
                 // Should have reverted if the `numSecsProcessed` > `frequency * numParts`
                 if (block.timestamp == endTime && receivedSelector == IConditionalOrder.OrderNotValid.selector) {
@@ -671,4 +671,11 @@ contract ComposableCoWTwapTest is BaseComposableCoWTest {
             appData: keccak256("test.twap")
         });
     }
+
+    /// @dev Leading selector of revert data. Widening casts only, so no truncation.
+    function _selector(bytes memory data) private pure returns (bytes4) {
+        require(data.length >= 4, "revert data has no selector");
+        return bytes4(data[0]) | (bytes4(data[1]) >> 8) | (bytes4(data[2]) >> 16) | (bytes4(data[3]) >> 24);
+    }
+
 }

--- a/test/libraries/TestAccountLib.t.sol
+++ b/test/libraries/TestAccountLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
 
 struct TestAccount {
     address addr;
@@ -9,15 +9,15 @@ struct TestAccount {
 }
 
 library TestAccountLib {
-    Vm constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+    Vm constant VM = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
     /// @dev Creates a new TestAccount with the provided user name.
     ///      Logic borrows from `StdCheats.sol`.
     function createTestAccount(string memory user) internal returns (TestAccount memory) {
         uint256 pk = uint256(keccak256(abi.encodePacked(user)));
-        address addr = vm.addr(pk);
-        vm.label(addr, user);
-        return TestAccount(addr, pk);
+        address addr = VM.addr(pk);
+        VM.label(addr, user);
+        return TestAccount({addr: addr, pk: pk});
     }
 
     /// @dev Sign the provided hash with the provided TestAccount.
@@ -25,7 +25,7 @@ library TestAccountLib {
     /// @param hash The hash to sign.
     /// @return The signature.
     function signPacked(TestAccount memory account, bytes32 hash) internal pure returns (bytes memory) {
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(account.pk, hash);
+        (uint8 v, bytes32 r, bytes32 s) = VM.sign(account.pk, hash);
 
         bytes memory signature = new bytes(65);
         signature = abi.encodePacked(r, s, v);


### PR DESCRIPTION
Fix some lint issues found in the tests.


- `priceToAddress` in the stop-loss test had no callers. Deleted, which removes two of the narrowing casts.
- `IERC165`, `ReceiverLock` and `INVALID_HASH` were re-exported through `ComposableCoW.base.t.sol`. The two consumers now import them from the real sources, so the re-exports can go — #149 said removing them fails to compile, which is true only if the importers are left alone.
- `uint32(endTime)` becomes `SafeCast.toUint32`; the fuzz already assumes it fits.
- `bytes4(lowLevelData)` becomes a `_selector` helper built from widening casts, with a length check.
- `bytes32("testValue")` becomes a named constant, `TestAccountLib` gets a named import, `VM`, and a named struct literal.

## Test plan

```sh
forge lint
forge test
```


Make sure now WARN apply only to `src/` or `lib/` directories