### PR TITLE
chore: make the model checker opt-in

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -13,7 +13,9 @@ cbor_metadata = false
 optimizer = true
 optimizer_runs = 20000
 
-[profile.default.model_checker]
+# Opt-in: needs z3, and every build without it warns once per compilation unit.
+# Run with `FOUNDRY_PROFILE=smt forge build`.
+[profile.smt.model_checker]
 contracts = { 'src/types/twap/libraries/TWAPOrderMathLib.sol' = [ 'TWAPOrderMathLib' ] }
 engine = 'chc'
 targets = [


### PR DESCRIPTION
Stacked on #150.

The CHC model checker ran on every build. CI has never had a solver, so since 2023 it warned 236 times a run and verified nothing; locally it warns 6 times and costs minutes.

Now opt-in. Run it with `FOUNDRY_PROFILE=smt forge build` when touching the TWAP math.

## Test plan

Finally the build now is clean! 🥳
```sh
forge build --force 
```

<img width="411" height="98" alt="image" src="https://github.com/user-attachments/assets/e40877f7-d820-4e93-9eff-0dccaca6164a" />


We can still run the checker, if we miss the WARNINGS.

```sh
FOUNDRY_PROFILE=smt forge build --force 
```

Test should pass:

```
forge test
```