### PR TITLE
build: target cancun with solc 0.8.30

### DIFF
--- a/canonical/README.md
+++ b/canonical/README.md
@@ -13,6 +13,11 @@ This folder keeps the initcode of the deployments that already exist, read back 
 transactions: one file per contract under `initcode/`, plus `manifest.json` recording each salt and
 resulting address.
 
+These addresses therefore do not depend on the compiler this repository is pinned to:
+[`dev/verify-canonical.sh`](../dev/verify-canonical.sh) recomputes every one of them from the
+recorded initcode, without compiling anything. To build these sources the way the deployments were
+built, use the `legacy` profile in [`foundry.toml`](../foundry.toml).
+
 Deploy it with [`dev/deploy-canonical.sh`](../dev/deploy-canonical.sh), which checks every file
 against `manifest.json` before sending anything. The target chain needs two contracts already in
 place, and the script stops if either is missing:

--- a/dev/verify-contracts.sh
+++ b/dev/verify-contracts.sh
@@ -32,6 +32,15 @@ address_by_contract_name() {
   printf "%s" "$(jq --raw-output ".${name}[\"$chain_id\"].address" "$networks_json")"
 }
 
+# The contracts in the canonical manifest were built with an older compiler; see foundry.toml.
+profile_for() {
+  if [[ "$(jq --raw-output --arg n "$1" 'has($n)' "$repo_root_dir/canonical/manifest.json")" == true ]]; then
+    printf legacy
+  else
+    printf default
+  fi
+}
+
 forge_verify() {
   local address=$1
   local contract=$2
@@ -74,7 +83,7 @@ for path in \
   contract="${filename%%.sol}"
   address="$(address_by_contract_name "$contract")"
   echo "Verifying contract $contract..."
-  forge_verify "$address" "$path:$contract"
+  FOUNDRY_PROFILE="$(profile_for "$contract")" forge_verify "$address" "$path:$contract"
 done
 
 echo "All done!"

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,9 +5,11 @@ out = 'out'
 libs = ['lib']
 
 # Pinned so the compiled bytecode, and therefore every CREATE2 address, is reproducible.
-solc_version = "0.8.19"
+solc_version = "0.8.30"
 auto_detect_solc = false
-evm_version = "paris"
+# `evm_version` also picks the EVM the scripts and tests simulate on, and CowShed is built for a
+# newer target: under `paris`, calling it dies on `MCOPY` with `NotActivated`.
+evm_version = "cancun"
 bytecode_hash = "none"
 cbor_metadata = false
 optimizer = true
@@ -20,6 +22,12 @@ targets = [
     'assert', 'underflow', 'overflow', 'divByZero', 'constantCondition', 'popEmptyArray', 'outOfBounds', 'balance'
 ]
 timeout = 100000
+
+# The contracts in `canonical/` were deployed from this repository at 0.8.19, targeting paris.
+# Build with this profile to reproduce, or verify, what is already on those addresses.
+[profile.legacy]
+solc_version = "0.8.19"
+evm_version = "paris"
 
 [profile.ci]
 verbosity = 3


### PR DESCRIPTION
Modernize the compiler version.

Before this PR we were stuck in `Paris` compiler. This PR upgrades to `Cancun`.

We mantain the compatibility of the legacy contracts (like TWAP). So we still have deterministic deployment, but all new contracts can use the new version.

## Main motivation
Well, we should upgrade the compiler to make sure we are up to date, this is reason enough, but what pushed me to this change is that the poller contract depends on cow-shed's Factory, which in its newer version (2.1.0) uses `Prague`, so it was a breaking change for this repository!

More concretelly, CowShed is built with solc 0.8.30, so its deployed code uses `MCOPY`, and any simulated call into it under `paris` dies with `NotActivated`.

After this PR I expect to be able to successfully deploy the new poller contract without issues https://github.com/cowprotocol/composable-cow/pull/155

## The canonical addresses do not move

They never depended on the compiler, they use`canonical/initcode/*.initcode`

## Test plan

Make sure tests pass
```bash
FOUNDRY_PROFILE=ci forge test 
```

Verify all recorded initcode matches the canonical addresses:
```sh
bash dev/verify-canonical.sh
```

Lint has no findings:
```
forge lint
```

`generate-networks-file.sh` generates no changes in the addresses: 
```sh
diff -u networks.json <(bash dev/generate-networks-file.sh)
```
