### PR TITLE
docs(poller): document the funder-controls-owner trust model

### DIFF
--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -130,10 +130,10 @@ contract ComposableCowPoller is EIP712 {
         bytes32 paramsHash
     );
 
-    /// @notice Emitted when a part's funds are moved.
-    /// @dev `orderDigest` is indexed so a single leg can be looked up directly, rather than only
-    ///      by walking a schedule's history. It is the CoW order struct hash, so it joins to
-    ///      settlement data.
+    /// @notice Emitted when a discrete order's funds are moved.
+    /// @dev `orderDigest` is indexed so a single discrete order can be looked up directly, rather
+    ///      than only by walking a schedule's history. It is the CoW order struct hash, so it
+    ///      joins to settlement data.
     /// @param id The deterministic key of the schedule.
     /// @param orderDigest The digest of the order that was funded.
     /// @param amount The `sellAmount` moved from the funder to the owner.
@@ -427,13 +427,13 @@ contract ComposableCowPoller is EIP712 {
     /// @notice Move the current order's `sellAmount` from the funder to the owner. Permissionless.
     ///         The full amount always moves (no balance check), so one owner can serve several
     ///         concurrent orders.
-    /// @dev Trust model: the funder must control `owner`. Every leg moves without checking that the
-    ///      previous one settled, so the owner is trusted with the whole notional either way. Two
-    ///      consequences are benign only under that assumption. The allowance is per
-    ///      `(funder, sellToken)` and shared across that funder's schedules, so it is not a
-    ///      per-schedule cap. And `funded` is keyed by order digest, so an owner who re-runs
-    ///      `createWithContext` on a cabinet-resolved TWAP gets a fresh `t0`, hence fresh digests,
-    ///      and funding restarts from the first part.
+    /// @dev Trust model: the funder must control `owner`. Each discrete order is funded without
+    ///      checking that the previous one settled, and the allowance is per `(funder, sellToken)`
+    ///      and shared across that funder's schedules rather than a per-schedule cap, so the owner
+    ///      is trusted with whatever the allowance permits. `funded` is keyed by order digest, so a
+    ///      handler resolving its start time from the cabinet - a TWAP with `t0 == 0` - yields fresh
+    ///      digests once the owner re-runs `createWithContext`, and funding restarts from the
+    ///      schedule's first discrete order.
     /// @return Whether funds moved. `false` means this order was already funded, which is the one
     ///         outcome a caller cannot otherwise tell apart from a transfer without diffing
     ///         balances; every other case reverts.

--- a/src/types/ComposableCowPoller.sol
+++ b/src/types/ComposableCowPoller.sol
@@ -59,7 +59,9 @@ contract ComposableCowPoller is EIP712 {
         /// @dev It can be an EOA or contract and may be the same address as `owner`.
         address funder;
         /// @notice The address that owns the ComposableCoW conditional order and receives the pulled funds.
-        /// @dev It can be an EOA or contract and may be the same address as `funder`.
+        /// @dev It can be an EOA or contract and may be the same address as `funder`, but the funder
+        ///      must control it: see the trust model on `pollFunds`. `registerFromShed` enforces
+        ///      that; `register` accepts any owner and leaves it to the funder.
         address owner;
         /// @notice The conditional order's own `salt`.
         /// @dev It is what keeps two otherwise-identical orders distinct in ComposableCoW, so use
@@ -77,6 +79,7 @@ contract ComposableCowPoller is EIP712 {
     mapping(bytes32 => Schedule) public schedules;
 
     /// @dev `id => orderDigest => funded`. History survives schedule updates so an old order cannot be replayed.
+    ///      Being digest-keyed, it does not bound a schedule's total spend; see `pollFunds`.
     mapping(bytes32 => mapping(bytes32 => bool)) public funded;
 
     /// @notice Thrown when someone other than the schedule funder registers, updates, or revokes a schedule.
@@ -187,6 +190,7 @@ contract ComposableCowPoller is EIP712 {
     /// @notice Registers a schedule.
     /// @dev Only the funder may register. Reverts if the schedule is active or its `authEpoch` does
     ///      not match storage. After revocation, the same ID can be registered in the next epoch.
+    ///      `schedule.owner` is unconstrained here; see the trust model on `pollFunds`.
     /// @param schedule The schedule to store.
     /// @return id The deterministic key of the stored schedule.
     function register(
@@ -423,6 +427,13 @@ contract ComposableCowPoller is EIP712 {
     /// @notice Move the current order's `sellAmount` from the funder to the owner. Permissionless.
     ///         The full amount always moves (no balance check), so one owner can serve several
     ///         concurrent orders.
+    /// @dev Trust model: the funder must control `owner`. Every leg moves without checking that the
+    ///      previous one settled, so the owner is trusted with the whole notional either way. Two
+    ///      consequences are benign only under that assumption. The allowance is per
+    ///      `(funder, sellToken)` and shared across that funder's schedules, so it is not a
+    ///      per-schedule cap. And `funded` is keyed by order digest, so an owner who re-runs
+    ///      `createWithContext` on a cabinet-resolved TWAP gets a fresh `t0`, hence fresh digests,
+    ///      and funding restarts from the first part.
     /// @return Whether funds moved. `false` means this order was already funded, which is the one
     ///         outcome a caller cannot otherwise tell apart from a transfer without diffing
     ///         balances; every other case reverts.

--- a/test/ComposableCowPoller.t.sol
+++ b/test/ComposableCowPoller.t.sol
@@ -762,6 +762,39 @@ contract ComposableCowPollerTest is BaseComposableCoWTest {
         assertTrue(poller.funded(id, GPv2Order.hash(orderB, composableCow.domainSeparator())));
     }
 
+    /// @dev The counterpart: re-running `createWithContext` resets the cabinet `t0`, which shifts
+    ///      every digest, so the first part is funded a second time. Expected, and safe only because
+    ///      the funder controls the owner; see the trust model on `pollFunds`.
+    function test_pollFunds_refundsFirstPartAfterCabinetRestart() public {
+        (IConditionalOrder.ConditionalOrderParams memory params, bytes32 paramsHash, bytes32 id) = _setupSchedule();
+        uint256 t0 = _t0(paramsHash);
+        vm.warp(t0);
+
+        GPv2Order.Data memory first =
+            twap.getTradeableOrder(address(safe1), address(poller), paramsHash, abi.encode(_bundle()), bytes(""));
+        assertTrue(poller.pollFunds(id), "first part funded");
+        vm.prank(address(safe1));
+        assertTrue(token0.transfer(bob.addr, TWAP_PART_AMOUNT), "first part settled");
+
+        // The owner restarts the same order a second later: identical params, so the same
+        // `paramsHash` and the same schedule, but a cabinet `t0` one second on.
+        vm.warp(t0 + 1);
+        _createWithContext(address(safe1), params, currentBlockTimestampFactory, bytes(""), false);
+        assertEq(_t0(paramsHash), t0 + 1, "cabinet start time reset");
+
+        GPv2Order.Data memory restarted =
+            twap.getTradeableOrder(address(safe1), address(poller), paramsHash, abi.encode(_bundle()), bytes(""));
+        assertEq(restarted.sellAmount, first.sellAmount, "still the first part's amount");
+        assertTrue(restarted.validTo != first.validTo, "the restart shifts `validTo`, hence the digest");
+
+        assertTrue(poller.pollFunds(id), "first part funded again");
+
+        assertEq(token0.balanceOf(address(safe1)), TWAP_PART_AMOUNT, "the same part pulled twice");
+        assertEq(token0.balanceOf(funder), TWAP_PART_AMOUNT * (N - 2), "two parts spent inside one window");
+        assertTrue(poller.funded(id, GPv2Order.hash(first, composableCow.domainSeparator())));
+        assertTrue(poller.funded(id, GPv2Order.hash(restarted, composableCow.domainSeparator())));
+    }
+
     /// @dev A failed ERC-20 transfer must not mark this part as funded.
     function test_pollFunds_RevertWhen_transferFromReturnsFalse() public {
         (, bytes32 paramsHash, bytes32 id) = _setupSchedule();


### PR DESCRIPTION
Documents the poller's trust model where the owner is picked, and pins the behaviour with a test.

`funded` is keyed by order digest, so a handler that resolves its start time from the cabinet — a TWAP with `t0 == 0` — restarts funding from the schedule's first discrete order whenever the owner re-runs `createWithContext`. The only bound is the ERC-20 allowance, which is per `(funder, sellToken)` and shared across that funder's schedules rather than a per-schedule cap.

Both are expected: `pollFunds` funds each discrete order without checking that the previous one settled, so the owner is trusted with whatever the allowance permits either way. That precondition just was not written down — the natspec on `Schedule.owner` read as permission to pick any address, where in practice it should be a CowShed the funder controls, as `registerFromShed` already enforces.

Comments only: with `bytecode_hash = "none"` and `cbor_metadata = false`, the bytecode and every CREATE2 address are unchanged.

## Test plan

- New test — funds the first part, settles it, warps 1s, re-runs `createWithContext`, asserts the same part is pulled again under a different digest. The warp is +1s rather than a whole `FREQ`, since a `FREQ` shift yields the digest the second part would have had anyway and would look like ordinary progression.

      forge test --match-test test_pollFunds_refundsFirstPartAfterCabinetRestart -vv

- Full suite, 138 passing:

      forge test

- Bytecode identical to `main` (`42deed289e018dbff72b4d6e2850b36f0bdcbf54a565fb17b86944fefcfca71c` on both):

      forge build && jq -r '.bytecode.object' out/ComposableCowPoller.sol/ComposableCowPoller.json | shasum -a 256
